### PR TITLE
Add back support for lifetime

### DIFF
--- a/src/derive_builder.rs
+++ b/src/derive_builder.rs
@@ -29,7 +29,7 @@ macro_rules! Builder {
     (
         @impl_struct
         struct_name = $struct_name:ident,
-        generics = ($($generics:ident),*),
+        generics = ($($generics:tt),*),
         fields = [$({
             field_name: $field_name:ident,
             field_ty: $field_ty:ty,
@@ -52,7 +52,7 @@ macro_rules! Builder {
     // Handle struct with generics
     (
         @parse
-        $struct_name:ident <$($generics:ident),*>
+        $struct_name:ident <$($generics:tt),*>
         $body:tt $(;)*
     ) => {
         __parse_struct_body! {

--- a/tests/lifetime.rs
+++ b/tests/lifetime.rs
@@ -1,0 +1,76 @@
+#[macro_use] extern crate custom_derive;
+#[macro_use] extern crate derive_builder;
+
+custom_derive!{
+    #[derive(Debug, PartialEq, Builder, Clone)]
+    struct Lorem<'a, T> {
+        ipsum: &'a str,
+        dolor: Option<T>,
+    }
+}
+
+impl<'a, T> Lorem<'a, T> {
+    pub fn new(ipsum: &'a str) -> Self {
+        Lorem {
+            ipsum: ipsum,
+            dolor: None,
+        }
+    }
+}
+
+custom_derive!{
+    #[derive(Debug, PartialEq, Builder, Clone)]
+    struct LoremNonGeneric<'a> {
+        ipsum: &'a str,
+        dolor: Option<&'a bool>,
+    }
+}
+
+impl<'a> LoremNonGeneric<'a> {
+    pub fn new(ipsum: &'a str) -> Self {
+        LoremNonGeneric {
+            ipsum: ipsum,
+            dolor: None,
+        }
+    }
+}
+
+
+#[test]
+fn contructor_sanity_check() {
+    let ipsum: String = "Ipsum with references to it".into();
+    let x: Lorem<()> = Lorem::new(&ipsum);
+
+    assert_eq!(x, Lorem { ipsum: &ipsum, dolor: None, });
+}
+
+#[test]
+fn setters() {
+    let ipsum: String = "Ipsum with references to it".into();
+    let dolor = true;
+    let x: Lorem<&bool> = Lorem::new(&ipsum)
+        .dolor(Some(&dolor)).
+        clone();
+
+    assert_eq!(x, Lorem { ipsum: &ipsum, dolor: Some(&dolor), });
+}
+
+
+#[test]
+fn contructor_sanity_check_nongeneric() {
+    let ipsum: String = "Ipsum with references to it".into();
+    let x: LoremNonGeneric = LoremNonGeneric::new(&ipsum);
+
+    assert_eq!(x, LoremNonGeneric { ipsum: &ipsum, dolor: None, });
+}
+
+#[test]
+fn setters_nongeneric() {
+    let ipsum: String = "Ipsum with references to it".into();
+    let dolor = true;
+    let x: LoremNonGeneric = LoremNonGeneric::new(&ipsum)
+        .dolor(Some(&dolor))
+        .clone();
+
+    assert_eq!(x, LoremNonGeneric { ipsum: &ipsum, dolor: Some(&dolor), });
+}


### PR DESCRIPTION
The patch on `src/derive_builder.rs` is quite straightforward, but the
test had to be adapted a little. Mainly, the `Lorem` struct had to derive
`Clone` and the created variable must call `clone()`, like it is done
in `tests/generic_structs.rs`.

See issue #21.

Original commit: fda318a9adc447396af31378d89800f13a2296cd
Reverting commit: 5b44190802d70ce64638842cabb77189e66aae19.