### PR TITLE
prefixed setters and field specific overrides

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,8 @@ before_script: |
   export PATH=$LOCAL/bin:$PATH
 script: |
   travis-cargo build &&
+  # doc-tests only work if env_logger is disabled (=> no-default-features)
+  travis-cargo test --no-default-features && 
   (cd derive-builder-test && travis-cargo test) &&
   travis-cargo doc
 after_success: |

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ before_script: |
 script: |
   travis-cargo build &&
   # doc-tests only work if env_logger is disabled (=> no-default-features)
-  travis-cargo test --no-default-features && 
+  travis-cargo test -- --no-default-features && 
   (cd derive-builder-test && travis-cargo test) &&
   travis-cargo doc
 after_success: |

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,7 @@ before_script: |
   export PATH=$LOCAL/bin:$PATH
 script: |
   travis-cargo build &&
-  # doc-tests only work if env_logger is disabled (=> no-default-features)
-  travis-cargo test -- --no-default-features && 
+  travis-cargo test &&
   (cd derive-builder-test && travis-cargo test) &&
   travis-cargo doc
 after_success: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,11 +4,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 ### Added
-- different setter pattern, e.g. `#[setters(immutable)]`
-- private setters, e.g. `#[setters(private)]`
+- different setter pattern, e.g. `#[setter(immutable)]`
+- private setters, e.g. `#[setter(private)]`
 - additional debug info via env_logger, e.g. `RUST_LOG=derive_builder=trace cargo test`
-- prefixes, e.g. `#[setters(prefix="with")]`
-- field specific overrides, e.g. `#[setter(prefix="with")]`
+- prefixes, e.g. `#[setter(prefix="with")]`
+- field specific overrides
 
 ### Changed
 - migration to macros 1.1, please refer to the new docs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - different setter pattern, e.g. `#[setters(immutable)]`
 - private setters, e.g. `#[setters(private)]`
 - additional debug info via env_logger, e.g. `RUST_LOG=derive_builder=trace cargo test`
+- prefixes, e.g. `#[setters(prefix="with")]`
+- field specific overrides, e.g. `#[setter(prefix="with")]`
 
 ### Changed
 - migration to macros 1.1, please refer to the new docs

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,8 +16,17 @@ readme = "README.md"
 [lib]
 proc-macro = true
 
+[features]
+# NOTE: We need to be able to disable initialisation of the env_logger to
+# have doc-tests right now. This might be a cargo bug! (TODO: check).
+#
+# As a workaround we keep the dependency on log otherwise we would need
+# to fake all the log macros.
+default = ["logging"]
+logging = ["env_logger"]
+
 [dependencies]
 syn = "0.10"
 quote = "0.3"
 log = "0.3"
-env_logger = "0.3"
+env_logger = { version = "0.3", optional = true }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,17 +16,8 @@ readme = "README.md"
 [lib]
 proc-macro = true
 
-[features]
-# NOTE: We need to be able to disable initialisation of the env_logger to
-# have doc-tests right now. This might be a cargo bug! (TODO: check).
-#
-# As a workaround we keep the dependency on log otherwise we would need
-# to fake all the log macros.
-default = ["logging"]
-logging = ["env_logger"]
-
 [dependencies]
 syn = "0.10"
 quote = "0.3"
 log = "0.3"
-env_logger = { version = "0.3", optional = true }
+env_logger = "0.3"

--- a/README.md
+++ b/README.md
@@ -54,8 +54,8 @@ pub fn special_info<VALUE: Into<i32>>(&mut self, value: VALUE) -> &mut Self {
 * **Setter type conversions**: Setter methods are generic over the input types – you can supply every argument that implements the [`Into`][into] trait for the field type.
 * **Generic structs**: Are also supported, but you **must not** use a type parameter named `VALUE`, because this is already reserved for the setter-methods.
 * **Documentation and attributes**: Setter methods can be documented by simply documenting the corresponding field. Similarly `#[cfg(...)]` and `#[allow(...)]` attributes are also applied to the setter methods.
-* **Builder patterns**: You can opt into other builder patterns by preceding your struct with `#[setters(owned)]` or `#[setters(immutable)]`.
-* **Visibility**: You can opt into private setter by preceding your struct with `#[setters(private)]`.
+* **Builder patterns**: You can opt into other builder patterns by preceding your struct with `#[setter(owned)]` or `#[setter(immutable)]`.
+* **Visibility**: You can opt into private setter by preceding your struct with `#[setter(private)]`.
 * **Logging**: If anything works unexpectedly you can enable detailed logs by setting this environment variable before calling cargo `RUST_LOG=derive_builder=trace`.
 
 For more information and examples please take a look at our [documentation][doc].

--- a/derive-builder-test/tests/generic_structs.rs
+++ b/derive-builder-test/tests/generic_structs.rs
@@ -6,6 +6,12 @@ struct GenLorem<T> {
     pub dolor: T, // generics are a pain, so this field name is fitting
 }
 
+#[derive(Debug, PartialEq, Default, Builder, Clone)]
+struct GenLorem2<T> {
+    ipsum: String,
+    pub dolor: T, // generics are a pain, so this field name is fitting
+}
+
 impl<T: Default> GenLorem<T> {
     pub fn new<V: Into<String>>(value: V) -> Self {
         GenLorem {

--- a/derive-builder-test/tests/immutable.rs
+++ b/derive-builder-test/tests/immutable.rs
@@ -1,7 +1,7 @@
 #[macro_use] extern crate derive_builder;
 
 #[derive(Debug, PartialEq, Default, Builder, Clone)]
-#[setters(immutable)]
+#[setter(immutable)]
 struct Lorem {
     ipsum: String,
 }

--- a/derive-builder-test/tests/multiple_derives.rs
+++ b/derive-builder-test/tests/multiple_derives.rs
@@ -2,9 +2,17 @@
 
 #[allow(dead_code)]
 #[derive(Builder)]
-struct IgnoreEmptyStruct {  }
+struct Foo {
+    lorem: bool
+}
+
+#[allow(dead_code)] 
+#[derive(Builder)]
+struct Bar {
+    ipsum: bool
+}
 
 #[test]
-fn empty_struct() {
+fn multiple_builder_derives() {
     // this is just a compile-test - no run time checks required.
 }

--- a/derive-builder-test/tests/mutable.rs
+++ b/derive-builder-test/tests/mutable.rs
@@ -1,7 +1,7 @@
 #[macro_use] extern crate derive_builder;
 
 #[derive(Debug, PartialEq, Default, Builder, Clone)]
-#[setters(mutable)]
+#[setter(mutable)]
 struct Lorem {
     ipsum: String,
 }

--- a/derive-builder-test/tests/owned.rs
+++ b/derive-builder-test/tests/owned.rs
@@ -1,7 +1,7 @@
 #[macro_use] extern crate derive_builder;
 
 #[derive(Debug, PartialEq, Default, Builder, Clone)]
-#[setters(owned)]
+#[setter(owned)]
 struct Lorem {
     ipsum: String,
 }

--- a/derive-builder-test/tests/private_setters.rs
+++ b/derive-builder-test/tests/private_setters.rs
@@ -2,7 +2,7 @@
 
 pub mod foo {
     #[derive(Debug, PartialEq, Default, Builder, Clone)]
-    #[setters(private)]
+    #[setter(private)]
     pub struct Lorem {
         pub ipsum: String,
     }

--- a/derive-builder-test/tests/setter_prefix.rs
+++ b/derive-builder-test/tests/setter_prefix.rs
@@ -1,0 +1,19 @@
+#[macro_use] extern crate derive_builder;
+
+#[derive(Debug, PartialEq, Default, Builder, Clone)]
+#[setters(prefix="with", option="implicit")]
+struct Lorem {
+    ipsum: String,
+    #[setter(prefix="set")]
+    pub dolor: Option<String>,
+}
+
+#[test]
+fn prefixed_setters() {
+    let x = Lorem::default()
+        .with_ipsum("ipsum")
+        .set_dolor(Some("dolor".into()))
+        .clone();
+
+    assert_eq!(x, Lorem { ipsum: "ipsum".into(), dolor: Some("dolor".into())});
+}

--- a/derive-builder-test/tests/setter_prefix.rs
+++ b/derive-builder-test/tests/setter_prefix.rs
@@ -1,7 +1,7 @@
 #[macro_use] extern crate derive_builder;
 
 #[derive(Debug, PartialEq, Default, Builder, Clone)]
-#[setters(prefix="with", option="implicit")]
+#[setter(prefix="with")]
 struct Lorem {
     ipsum: String,
     #[setter(prefix="set")]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -221,15 +221,15 @@ use std::borrow::Cow;
 use proc_macro::TokenStream;
 use quote::ToTokens;
 use options::{Options, OptionsBuilder, FieldMode, SetterPattern};
+use std::sync::atomic::{AtomicBool, Ordering, ATOMIC_BOOL_INIT};
 
 // beware: static muts are not threadsafe. :-)
-static mut LOGGER_INITIALIZED: bool = false;
+static mut LOGGER_INITIALIZED: AtomicBool = ATOMIC_BOOL_INIT; // false
 
 #[doc(hidden)]
 #[proc_macro_derive(Builder, attributes(setter))]
 pub fn derive(input: TokenStream) -> TokenStream {
-    if unsafe { !LOGGER_INITIALIZED } {
-        unsafe { LOGGER_INITIALIZED = true }
+    if unsafe { !LOGGER_INITIALIZED.compare_and_swap(false, true, Ordering::SeqCst) } {
         env_logger::init().unwrap();
     }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -213,7 +213,6 @@ extern crate syn;
 extern crate quote;
 #[macro_use]
 extern crate log;
-#[cfg(feature = "logging")]
 extern crate env_logger;
 
 mod options;
@@ -223,11 +222,16 @@ use proc_macro::TokenStream;
 use quote::ToTokens;
 use options::{Options, OptionsBuilder, FieldMode, SetterPattern};
 
+// beware: static muts are not threadsafe. :-)
+static mut LOGGER_INITIALIZED: bool = false;
+
 #[doc(hidden)]
 #[proc_macro_derive(Builder, attributes(setter))]
 pub fn derive(input: TokenStream) -> TokenStream {
-    #[cfg(feature = "logging")]
-    env_logger::init().unwrap();
+    if unsafe { !LOGGER_INITIALIZED } {
+        unsafe { LOGGER_INITIALIZED = true }
+        env_logger::init().unwrap();
+    }
 
     let input = input.to_string();
 


### PR DESCRIPTION
Ok, here is my prototype for
- field specific overrides
- prefixed setters

My approach was to replace `struct OptionsBuilder` with `struct OptionsBuilder<Mode: OptionsBuilderMode>`

Obviously there is a struct mode and field mode: https://github.com/colin-kiegel/rust-derive-builder/blob/feature/field-overrides/src/options.rs#L87-L107

I then do this to get field specific overrides on the options defined for the struct
https://github.com/colin-kiegel/rust-derive-builder/blob/feature/field-overrides/src/lib.rs#L271-L273

The approach is optimized for basically identical options on struct and fields. As soon as we will get options specific to one of these modes, we need to introduce fields and impls on the ModeStructs itself.

PS: I just realized that I didn't need the phantom data, I could just embed the Mode structs. LOL. ^^