### PR TITLE
Feature/skip setter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,14 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-### Fixed
+### Added
+- skip setters, e.g. `#[builder(setter(skip))]`
 
+### Changed
+- deprecated syntax `#[builder(setter_prefix="with")]`,
+  please use `#[builder(setter(prefix="with"))]` instead
+
+### Fixed
 - use full path for result #39
 - support `#[deny(missing_docs)]` #37
 

--- a/README.md
+++ b/README.md
@@ -87,7 +87,8 @@ with [cargo-edit](https://github.com/killercup/cargo-edit):
 * **Builder patterns**: You can opt into other builder patterns by preceding your struct (or field) with `#[builder(pattern="owned")]` or `#[builder(pattern="immutable")]`.
 * **Extensible**: You can still define your own implementations for the builder struct and define additional methods. Just make sure to name them differently than the setter and build methods.
 * **Documentation and attributes**: Setter methods can be documented by simply documenting the corresponding field. Similarly `#[cfg(...)]` and `#[allow(...)]` attributes are also applied to the setter methods.
-* **Visibility**: You can opt into private setter by preceding your struct with `#[builder(private)]`.
+* **Hidden fields**: You can skip setters via `#[builder(setter(skip))]` on each field individually.
+* **Setter visibility**: You can opt into private setter by preceding your struct with `#[builder(private)]`.
 * **Setter type conversions**: Setter methods are generic over the input types – you can supply every argument that implements the [`Into`][into] trait for the field type.
 * **Generic structs**: Are also supported, but you **must not** use a type parameter named `VALUE`, because this is already reserved for the setter-methods.
 * **Logging**: If anything works unexpectedly you can enable detailed logs by setting this environment variable before calling cargo `RUST_LOG=derive_builder=trace`.

--- a/examples/deprecation_test.rs
+++ b/examples/deprecation_test.rs
@@ -1,0 +1,12 @@
+#[macro_use]
+extern crate derive_builder;
+
+// this is meant to generate a deprecation warning! :-)
+#[allow(dead_code)]
+#[derive(Builder)]
+struct Lorem {
+    #[builder(setter_prefix="old_syntax")]
+    ipsum: String,
+}
+
+fn main() {}

--- a/src/deprecation_notes.rs
+++ b/src/deprecation_notes.rs
@@ -1,0 +1,31 @@
+use quote::{Tokens, ToTokens};
+use syn;
+
+/// Deprecation notes we want to emit to the user.
+#[derive(Debug, Default, Clone)]
+pub struct DeprecationNotes(Vec<String>);
+
+impl DeprecationNotes {
+    /// Appends a note to the collection.
+    pub fn push(&mut self, note: String) {
+        self.0.push(note)
+    }
+}
+
+/// This will emit a block which can be inserted into any fn body to emit a
+/// deprecation warning in the downstream crate. Cool stuff. ^^
+/// Proof of concept: https://play.rust-lang.org/?gist=8394141c07d1f6d75d314818389eb4d8&version=stable&backtrace=0
+impl ToTokens for DeprecationNotes {
+    fn to_tokens(&self, tokens: &mut Tokens) {
+        for note in &self.0 {
+            let fn_ident = syn::Ident::new("derive_builder_deprecation_notice");
+            tokens.append(&quote!(
+                {
+                    #[deprecated(note=#note)]
+                    fn #fn_ident() { }
+                    #fn_ident();
+                }
+            ).to_string());
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -273,6 +273,7 @@ extern crate log;
 extern crate env_logger;
 
 mod options;
+mod deprecation_notes;
 
 use std::borrow::Cow;
 use proc_macro::TokenStream;
@@ -470,10 +471,13 @@ fn derive_setter(f: &syn::Field, opts: &FieldOptions, attrs: &AttrVec)
             Cow::Borrowed(fieldname)
         };
 
+        let deprecation_notes = opts.deprecation_notes();
+
         let setter = match *pattern {
             SetterPattern::Owned => quote!(
                     #(#attrs)*
                     #vis fn #funcname<VALUE: ::std::convert::Into<#ty>>(self, value: VALUE) -> Self {
+                        #deprecation_notes
                         let mut new = self;
                         new.#fieldname = ::std::option::Option::Some(value.into());
                         new
@@ -481,6 +485,7 @@ fn derive_setter(f: &syn::Field, opts: &FieldOptions, attrs: &AttrVec)
             SetterPattern::Mutable => quote!(
                     #(#attrs)*
                     #vis fn #funcname<VALUE: ::std::convert::Into<#ty>>(&mut self, value: VALUE) -> &mut Self {
+                        #deprecation_notes
                         let mut new = self;
                         new.#fieldname = ::std::option::Option::Some(value.into());
                         new
@@ -488,6 +493,7 @@ fn derive_setter(f: &syn::Field, opts: &FieldOptions, attrs: &AttrVec)
             SetterPattern::Immutable => quote!(
                     #(#attrs)*
                     #vis fn #funcname<VALUE: ::std::convert::Into<#ty>>(&self, value: VALUE) -> Self {
+                        #deprecation_notes
                         let mut new = ::std::clone::Clone::clone(self);
                         new.#fieldname = ::std::option::Option::Some(value.into());
                         new

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -194,6 +194,34 @@
 //! # fn main() {}
 //! ```
 //!
+//! ## Hidden Fields
+//!
+//! You can hide fields by skipping their setters on the builder struct.
+//!
+//! - Opt-out &mdash; skip setters via `#[builder(setter(skip))]` on individual fields.
+//! - Opt-in &mdash; set `#[builder(setter(skip))]` on the whole struct
+//!   and enable individual setters via `#[builder(setter)]`.
+//!
+//! The types of skipped fields must implement `Default`.
+//!
+//! ```rust
+//! # #[macro_use]
+//! # extern crate derive_builder;
+//! #
+//! #[derive(Builder)]
+//! struct SetterOptOut {
+//!     setter_present: u32,
+//!     #[builder(setter(skip))]
+//!     setter_skipped: u32,
+//! }
+//! # fn main() {}
+//! ```
+//!
+//! Alternatively you can use the more verbose form:
+//!
+//! - `#[builder(setter(skip="true"))]`
+//! - `#[builder(setter(skip="false"))]`
+//!
 //! ## Setter Visibility
 //!
 //! Setters are public by default. You can precede your struct (or field) with `#[builder(public)]`
@@ -206,7 +234,7 @@
 //!
 //! Setter methods are named after their corresponding field by default.
 //!
-//! You can precede your struct (or field) with e.g. `#[builder(setter_prefix="xyz")` to change
+//! You can precede your struct (or field) with e.g. `#[builder(setter(prefix="xyz"))` to change
 //! the method name to `xyz_foo` if the field is named `foo`. Note that an underscore is included
 //! by default, since Rust favors snake case here.
 //!
@@ -341,9 +369,6 @@ fn builder_for_struct(ast: syn::MacroInput) -> quote::Tokens {
         setter_fns.push(derive_setter(f, &f_opts, &attrs));
         builder_fields.push(derive_builder_field(f, &f_opts, &attrs));
         initializers.push(derive_initializer(f, &f_opts));
-        // NOTE: Looking forward for computation in interpolation
-        // - https://github.com/dtolnay/quote/issues/10
-        // => `quote!(#{f.vis} ...)
     }
 
     let builder_vis = opts.builder_visibility();
@@ -425,7 +450,7 @@ fn derive_initializer(f: &syn::Field, opts: &FieldOptions) -> quote::Tokens {
         initializer
     } else {
         trace!("Fallback to default initializer for `{}`.", opts.field_name());
-        quote!( #ident: default::Default(), )
+        quote!( #ident: Default::default(), )
     }
 }
 

--- a/tests/setter_prefix.rs
+++ b/tests/setter_prefix.rs
@@ -23,8 +23,3 @@ fn prefixed_setters() {
                    dolor: Some("dolor".into()),
                });
 }
-
-#[test]
-fn deprecation_notice() {
-    panic!(r#"TODO: improve the deprecation notice"#);
-}

--- a/tests/setter_prefix.rs
+++ b/tests/setter_prefix.rs
@@ -2,10 +2,10 @@
 extern crate derive_builder;
 
 #[derive(Debug, PartialEq, Default, Builder, Clone)]
-#[builder(setter_prefix="with")]
+#[builder(setter(prefix="with"))]
 struct Lorem {
     ipsum: String,
-    #[builder(setter_prefix="set")]
+    #[builder(setter(prefix="set"))]
     pub dolor: Option<String>,
 }
 
@@ -22,4 +22,9 @@ fn prefixed_setters() {
                    ipsum: "ipsum".into(),
                    dolor: Some("dolor".into()),
                });
+}
+
+#[test]
+fn deprecation_notice() {
+    panic!(r#"TODO: improve the deprecation notice"#);
 }

--- a/tests/skip-setter.rs
+++ b/tests/skip-setter.rs
@@ -46,11 +46,11 @@ fn setter_opt_out() {
         .unwrap();
 
     assert_eq!(x,
-        SetterOptOut {
-            setter_present_by_explicit_default: 42,
-            setter_skipped_by_explicit_opt_out: 0,
-            setter_skipped_by_shorthand_opt_out: 0,
-        });
+               SetterOptOut {
+                   setter_present_by_explicit_default: 42,
+                   setter_skipped_by_explicit_opt_out: 0,
+                   setter_skipped_by_shorthand_opt_out: 0,
+               });
 }
 
 #[test]
@@ -62,9 +62,9 @@ fn setter_opt_in() {
         .unwrap();
 
     assert_eq!(x,
-        SetterOptIn {
-            setter_skipped_by_shorthand_default: 0,
-            setter_present_by_explicit_opt_in: 47,
-            setter_present_by_shorthand_opt_in: 11,
-        });
+               SetterOptIn {
+                   setter_skipped_by_shorthand_default: 0,
+                   setter_present_by_explicit_opt_in: 47,
+                   setter_present_by_shorthand_opt_in: 11,
+               });
 }

--- a/tests/skip-setter.rs
+++ b/tests/skip-setter.rs
@@ -1,0 +1,70 @@
+// https://github.com/colin-kiegel/rust-derive-builder/issues/15
+#[macro_use]
+extern crate derive_builder;
+
+#[derive(Debug, PartialEq, Default, Builder, Clone)]
+#[builder(setter(skip="false"))]
+struct SetterOptOut {
+    setter_present_by_explicit_default: u32,
+    #[builder(setter(skip="true"))]
+    setter_skipped_by_explicit_opt_out: u32,
+    #[builder(setter(skip))]
+    setter_skipped_by_shorthand_opt_out: u32,
+}
+
+#[derive(Debug, PartialEq, Default, Builder, Clone)]
+#[builder(setter(skip))]
+struct SetterOptIn {
+    setter_skipped_by_shorthand_default: u32,
+    #[builder(setter(skip="false"))]
+    setter_present_by_explicit_opt_in: u32,
+    #[builder(setter)]
+    setter_present_by_shorthand_opt_in: u32,
+}
+
+// compile test
+#[allow(dead_code)]
+impl SetterOptOut {
+    // only possible if setter was skipped
+    fn setter_skipped_by_explicit_opt_out() {}
+    // only possible if setter was skipped
+    fn setter_skipped_by_shorthand_opt_out() {}
+}
+
+// compile test
+#[allow(dead_code)]
+impl SetterOptIn {
+    // only possible if setter was skipped
+    fn setter_skipped_by_shorthand_default() {}
+}
+
+#[test]
+fn setter_opt_out() {
+    let x: SetterOptOut = SetterOptOutBuilder::default()
+        .setter_present_by_explicit_default(42u32)
+        .build()
+        .unwrap();
+
+    assert_eq!(x,
+        SetterOptOut {
+            setter_present_by_explicit_default: 42,
+            setter_skipped_by_explicit_opt_out: 0,
+            setter_skipped_by_shorthand_opt_out: 0,
+        });
+}
+
+#[test]
+fn setter_opt_in() {
+    let x: SetterOptIn = SetterOptInBuilder::default()
+        .setter_present_by_explicit_opt_in(47u32)
+        .setter_present_by_shorthand_opt_in(11u32)
+        .build()
+        .unwrap();
+
+    assert_eq!(x,
+        SetterOptIn {
+            setter_skipped_by_shorthand_default: 0,
+            setter_present_by_explicit_opt_in: 47,
+            setter_present_by_shorthand_opt_in: 11,
+        });
+}


### PR DESCRIPTION
- skip setters, e.g. `#[builder(setter(skip))]`
  https://github.com/colin-kiegel/rust-derive-builder/issues/15
- deprecated syntax `#[builder(setter_prefix="with")]`,
  please use `#[builder(setter(prefix="with"))]` instead
- Custom derives can't emit nice warnings to the user??
  Hah! Have a look at [this](https://github.com/colin-kiegel/rust-derive-builder/commit/4c712d71b469ff3e544371fc84f5b65320332899) and [this](https://travis-ci.org/colin-kiegel/rust-derive-builder/jobs/203264430#L351-L357)! :-)