### PR TITLE
officially support `#![no_std]` #41

### DIFF
--- a/derive_builder/CHANGELOG.md
+++ b/derive_builder/CHANGELOG.md
@@ -20,6 +20,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - use full path for result #39
 - support `#[deny(missing_docs)]` #37
+- support `#![no_std]` via `#[builder(no_std)]` #41
 
 ## [0.3.0] - 2017-02-05
 

--- a/derive_builder/README.md
+++ b/derive_builder/README.md
@@ -92,6 +92,7 @@ with [cargo-edit](https://github.com/killercup/cargo-edit):
 * **Setter visibility**: You can opt into private setter by preceding your struct with `#[builder(private)]`.
 * **Setter type conversions**: With ``#[builder(setter(into))]`, setter methods will be generic over the input types – you can then supply every argument that implements the [`Into`][into] trait for the field type.
 * **Generic structs**: Are also supported, but you **must not** use a type parameter named `VALUE`, if you also activate setter type conversions.
+*  **no_std support**: Just add `#[builder(no_std)]` to your struct and add `extern crate collections` to your crate. The latter requires the _nightly_ toolchain.
 * **Logging**: If anything works unexpectedly you can enable detailed logs in two steps. First, add `features = ["logging"]` to the `derive_builder` dependency in `Cargo.toml`. Second, set this environment variable before calling cargo `RUST_LOG=derive_builder=trace`.
 
 For more information and examples please take a look at our [documentation][doc].

--- a/derive_builder/src/lib.rs
+++ b/derive_builder/src/lib.rs
@@ -346,6 +346,13 @@
 //! # fn main() {}
 //! ```
 //!
+//! # **`#![no_std]`** Support (on Nightly)
+//!
+//! You can activate support for `#![no_std]` by adding `#[builder(no_std)]` to your struct
+//! and `#![feature(collections)] extern crate collections` to your crate.
+//!
+//! The latter requires the _nightly_ toolchain.
+//!
 //! # Troubleshooting
 //!
 //! ## Gotchas

--- a/derive_builder/src/options/field_mode.rs
+++ b/derive_builder/src/options/field_mode.rs
@@ -98,6 +98,11 @@ impl OptionsBuilderMode for FieldMode {
     fn where_diagnostics(&self) -> String {
         format!("on field `{}`", self.field_ident.as_ref())
     }
+
+    fn no_std(&mut self, _x: bool) {
+        panic!("Support for `#![no_std]` can only be set on the stuct level (but found {}).",
+               self.where_diagnostics())
+    }
 }
 
 impl From<OptionsBuilder<FieldMode>> for FieldOptions {

--- a/derive_builder/src/options/macros.rs
+++ b/derive_builder/src/options/macros.rs
@@ -1,0 +1,48 @@
+/// Helper macro to generate a setter for some `Option<T>`.
+///
+/// The setter will panic if the Option is already initialized.
+///
+/// # Examples
+///
+/// ```rust, ignore
+/// OptionsBuilder {
+///    foo: Option<u32>,
+/// }
+///
+/// impl OptionsBuilder {
+///     impl_setter!{
+///        ident: foo,
+///        desc: "foo",
+///        map: |x: u32| { x },
+///    }
+/// }
+/// ```
+macro_rules! impl_setter {
+    (
+        ident: $ident:ident,
+        desc: $desc:expr,
+        map: |$x:ident: $ty:ty| {$( $map:tt )*},
+    ) => {
+        impl_setter!{
+            ident: $ident for $ident,
+            desc: $desc,
+            map: |$x: $ty| {$( $map )*},
+        }
+    };
+    (
+        ident: $setter:ident for $field:ident,
+        desc: $desc:expr,
+        map: |$x:ident: $ty:ty| {$( $map:tt )*},
+    ) => {
+        fn $setter(&mut self, $x: $ty) {
+            if let Some(ref current) = self.$field {
+                panic!("Failed to set {} to `{:?}` (already defined as `{:?}`) {}.",
+                    $desc,
+                    $x,
+                    current,
+                    self.where_diagnostics());
+            }
+            self.$field = Some({$( $map )*});
+        }
+    }
+}

--- a/derive_builder/src/options/struct_options.rs
+++ b/derive_builder/src/options/struct_options.rs
@@ -21,6 +21,8 @@ pub struct StructOptions {
     pub deprecation_notes: DeprecationNotes,
     /// Number of fields on the target struct.
     pub struct_size_hint: usize,
+    /// Whether the generated code should comply with `#![no_std]`.
+    pub no_std: bool,
 }
 
 impl StructOptions {
@@ -49,6 +51,7 @@ impl StructOptions {
             target_ty_generics: Some(ty_generics),
             initializers: Vec::with_capacity(self.struct_size_hint),
             doc_comment: None,
+            no_std: self.no_std,
         }
     }
 }

--- a/derive_builder_test/tests/run-pass/no_std.rs
+++ b/derive_builder_test/tests/run-pass/no_std.rs
@@ -1,6 +1,6 @@
 // requires nightly toolchain!
 #![no_std]
-#![feature(collections)]
+#![feature(collections, lang_items, start)]
 #![allow(dead_code)]
 
 #[macro_use]
@@ -10,3 +10,20 @@ extern crate collections;
 #[derive(Builder)]
 #[builder(no_std)]
 struct IgnoreEmptyStruct {}
+
+///////////////////////////////////////////////////////////////
+// some no_std-boilerplate
+// from https://doc.rust-lang.org/book/no-stdlib.html
+///////////////////////////////////////////////////////////////
+
+// These functions and traits are used by the compiler, but not
+// for a bare-bones hello world. These are normally
+// provided by libstd.
+#[lang = "eh_personality"] extern fn eh_personality() {}
+#[lang = "panic_fmt"] fn panic_fmt() -> ! { loop {} }
+
+// Entry point for this program
+#[start]
+fn start(_argc: isize, _argv: *const *const u8) -> isize {
+    0
+}

--- a/derive_builder_test/tests/run-pass/no_std.rs
+++ b/derive_builder_test/tests/run-pass/no_std.rs
@@ -1,0 +1,12 @@
+// requires nightly toolchain!
+#![no_std]
+#![feature(collections)]
+#![allow(dead_code)]
+
+#[macro_use]
+extern crate derive_builder;
+extern crate collections;
+
+#[derive(Builder)]
+#[builder(no_std)]
+struct IgnoreEmptyStruct {}


### PR DESCRIPTION
cc @cramertj

This is work in progress and does not work yet.

open questions
- how do we tell cargo or travis that a certain test should only run on nightly rust? (#![feature(collections)] requires nightly)
- something **strange** happens with this code.
```rust
quote!(
    #[cfg(not(no_std))]
    #builder_vis fn build(#ref_self) -> ::std::result::Result<#struct_name #ty_generics, ::std::string::String> {
        /* ... */
    }
    #[cfg(no_std)]
    #builder_vis fn build(#ref_self) -> ::core::result::Result<#struct_name #ty_generics, ::collections::string::String> {
        /* ... */
    }
)
```

The expanded code _only_ contains the first part
```rust
#[cfg(not(no_std))]
#builder_vis fn build(#ref_self) -> ::std::result::Result<#struct_name #ty_generics, ::std::string::String> {
    /* ... */
}
```

It's like the cfg-attributes always evaluate to `#[cfg(not(no_std))]==true` and `#[cfg(no_std)]==false` -- independently of the testcase. I would not be surprised if this was a rust or cargo bug evaluating the cfg-attribute in the wrong context - otherwise I don't understand it.