### PR TITLE
put #[deny(warnings)] behind a feature flag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ rust:
 matrix:
   include:
     - rust: nightly
-      env: JOB=build CARGO_FEATURES=dev_nightly
+      env: JOB=build CARGO_FEATURES="dev_nightly deny_warnings"
     - rust: nightly
       env: JOB=style_check CARGO_FEATURES=dev_nightly
   allow_failures:

--- a/derive_builder/Cargo.toml
+++ b/derive_builder/Cargo.toml
@@ -23,6 +23,7 @@ proc-macro = true
 
 [features]
 dev_nightly = ["compiletest_rs"]
+deny_warnings = []
 
 [dependencies]
 syn = "0.11"

--- a/derive_builder/src/lib.rs
+++ b/derive_builder/src/lib.rs
@@ -270,7 +270,7 @@
 //! [`derive_builder_core`]: https://crates.io/crates/derive_builder_core
 
 #![crate_type = "proc-macro"]
-#![deny(warnings)]
+#![cfg_attr(feature = "deny_warnings", deny(warnings))]
 
 extern crate proc_macro;
 extern crate syn;

--- a/derive_builder_core/Cargo.toml
+++ b/derive_builder_core/Cargo.toml
@@ -15,6 +15,9 @@ readme = "README.md"
 [badges]
 travis-ci = { repository = "colin-kiegel/rust-derive-builder" }
 
+[features]
+deny_warnings = []
+
 [dependencies]
 syn = "0.11"
 quote = "0.3"

--- a/derive_builder_core/src/lib.rs
+++ b/derive_builder_core/src/lib.rs
@@ -21,7 +21,8 @@
 //! [`derive_builder`]: https://!crates.io/crates/derive_builder
 //! [`derive_builder_core`]: https://!crates.io/crates/derive_builder_core
 
-#![deny(warnings, missing_docs)]
+#![warn(missing_docs)]
+#![cfg_attr(feature = "deny_warnings", deny(warnings))]
 
 extern crate proc_macro;
 extern crate syn;

--- a/derive_builder_test/Cargo.toml
+++ b/derive_builder_test/Cargo.toml
@@ -10,6 +10,7 @@ path = "src/lib.rs"
 
 [features]
 dev_nightly = ["compiletest_rs"]
+deny_warnings = []
 
 [dependencies]
 derive_builder = { path = "../derive_builder" }

--- a/derive_builder_test/src/lib.rs
+++ b/derive_builder_test/src/lib.rs
@@ -1,3 +1,5 @@
+#![cfg_attr(feature = "deny_warnings", deny(warnings))]
+
 #[macro_use]
 extern crate derive_builder;
 


### PR DESCRIPTION
- restore default warning behaviour for cargo,
  which is useful for local development
- travis builds will still deny warnings,
  but only on nightly, which seems sufficient.