### PR TITLE
opt into generic setters

### DIFF
--- a/derive_builder/CHANGELOG.md
+++ b/derive_builder/CHANGELOG.md
@@ -6,7 +6,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - skip setters, e.g. `#[builder(setter(skip))]`
-- custom defaults, e.g. `#[builder(default="42")]`
+- default values, e.g. `#[builder(default="42")]` or just `#[builder(default)]`
 
 ### Changed
 - deprecated syntax `#[builder(setter_prefix="with")]`,

--- a/derive_builder/CHANGELOG.md
+++ b/derive_builder/CHANGELOG.md
@@ -11,6 +11,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 - deprecated syntax `#[builder(setter_prefix="with")]`,
   please use `#[builder(setter(prefix="with"))]` instead
+- setter conversions are now off by default, you can opt-into via
+  `#[builder(setter(into))]`
 
 ### Fixed
 - use full path for result #39

--- a/derive_builder/README.md
+++ b/derive_builder/README.md
@@ -17,6 +17,7 @@
 extern crate derive_builder;
 
 #[derive(Default, Builder, Debug)]
+#[builder(setter(into))]
 struct Channel {
     token: i32,
     special_info: i32,
@@ -89,8 +90,8 @@ with [cargo-edit](https://github.com/killercup/cargo-edit):
 * **Documentation and attributes**: Setter methods can be documented by simply documenting the corresponding field. Similarly `#[cfg(...)]` and `#[allow(...)]` attributes are also applied to the setter methods.
 * **Hidden fields**: You can skip setters via `#[builder(setter(skip))]` on each field individually.
 * **Setter visibility**: You can opt into private setter by preceding your struct with `#[builder(private)]`.
-* **Setter type conversions**: Setter methods are generic over the input types – you can supply every argument that implements the [`Into`][into] trait for the field type.
-* **Generic structs**: Are also supported, but you **must not** use a type parameter named `VALUE`, because this is already reserved for the setter-methods.
+* **Setter type conversions**: With ``#[builder(setter(into))]`, setter methods will be generic over the input types – you can then supply every argument that implements the [`Into`][into] trait for the field type.
+* **Generic structs**: Are also supported, but you **must not** use a type parameter named `VALUE`, if you also activate setter type conversions.
 * **Logging**: If anything works unexpectedly you can enable detailed logs by setting this environment variable before calling cargo `RUST_LOG=derive_builder=trace`.
 
 For more information and examples please take a look at our [documentation][doc].

--- a/derive_builder/examples/channel.rs
+++ b/derive_builder/examples/channel.rs
@@ -21,6 +21,7 @@ impl From<i32> for Authentication {
 }
 
 #[derive(Debug, Default, Builder)]
+#[builder(setter(into))]
 struct Channel {
     id: Uuid,
     token: Authentication,

--- a/derive_builder/examples/custom_defaults.rs
+++ b/derive_builder/examples/custom_defaults.rs
@@ -35,7 +35,7 @@ impl LoremBuilder {
 
 fn main() {
     let x = LoremBuilder::default()
-        .ipsum("ipsum")
+        .ipsum("ipsum".to_string())
         .build()
         .unwrap();
 

--- a/derive_builder/examples/deny_missing_docs.rs
+++ b/derive_builder/examples/deny_missing_docs.rs
@@ -8,6 +8,7 @@ extern crate derive_builder;
 
 /// Traditional form of communication.
 #[derive(Debug, Builder)]
+#[builder(setter(into))]
 pub struct Letter {
     /// Be creative.
     pub message: String,

--- a/derive_builder/examples/doc_example.rs
+++ b/derive_builder/examples/doc_example.rs
@@ -8,7 +8,7 @@ extern crate derive_builder;
 #[allow(dead_code)]
 #[derive(Builder)]
 struct Lorem {
-    ipsum: String,
+    ipsum: u32,
 }
 
 fn main() {}

--- a/derive_builder/examples/readme_example.rs
+++ b/derive_builder/examples/readme_example.rs
@@ -6,6 +6,7 @@
 extern crate derive_builder;
 
 #[derive(Default, Builder, Debug)]
+#[builder(setter(into))]
 struct Channel {
     token: i32,
     special_info: i32,

--- a/derive_builder/src/options/field_mode.rs
+++ b/derive_builder/src/options/field_mode.rs
@@ -26,6 +26,7 @@ impl OptionsBuilder<FieldMode> {
         let ident = f.ident.expect(&format!("Missing identifier for field of type `{:?}`.", f.ty));
         trace!("Parsing field `{}`.", ident.as_ref());
 
+        // Note: Set `field_ident` _before_ parsing attributes, for better diagnostics!
         let mut builder = Self::from(FieldMode {
             field_ident: ident,
             field_type: f.ty,
@@ -83,12 +84,18 @@ impl OptionsBuilder<FieldMode> {
 
 impl OptionsBuilderMode for FieldMode {
     fn parse_builder_name(&mut self, _name: &syn::Lit) {
-        panic!("Builder name can only be set on the stuct level")
+        panic!("Builder name can only be set on the stuct level (but found {}).",
+               self.where_diagnostics())
     }
 
     fn push_deprecation_note<T: Into<String>>(&mut self, x: T) -> &mut Self {
         self.deprecation_notes.push(x.into());
         self
+    }
+
+    /// Provide a diagnostic _where_-clause for panics.
+    fn where_diagnostics(&self) -> String {
+        format!("on field `{}`", self.field_ident.as_ref())
     }
 }
 

--- a/derive_builder/src/options/field_mode.rs
+++ b/derive_builder/src/options/field_mode.rs
@@ -76,6 +76,7 @@ impl OptionsBuilder<FieldMode> {
             setter_prefix: f!(setter_prefix),
             setter_vis: f!(setter_vis),
             default_expression: f!(default_expression),
+            setter_into: f!(setter_into),
             mode: mode,
         }
     }
@@ -122,6 +123,7 @@ impl From<OptionsBuilder<FieldMode>> for FieldOptions {
             setter_visibility: b.setter_vis.clone().unwrap_or(syn::Visibility::Public),
             field_ident: field_ident,
             field_type: field_type,
+            setter_into: b.setter_into.unwrap_or(false),
             deprecation_notes: b.mode.deprecation_notes.clone(),
             default_expression: b.default_expression.clone(),
             attrs: b.mode.setter_attrs.clone().unwrap_or_default(),

--- a/derive_builder/src/options/field_options.rs
+++ b/derive_builder/src/options/field_options.rs
@@ -18,6 +18,8 @@ pub struct FieldOptions {
     pub field_ident: syn::Ident,
     /// The field type.
     pub field_type: syn::Ty,
+    /// Make the setter generic over `Into<_>`.
+    pub setter_into: bool,
     /// Emit deprecation notes to the user,
     /// e.g. if a deprecated attribute was used in `derive_builder`.
     pub deprecation_notes: DeprecationNotes,
@@ -42,6 +44,7 @@ impl FieldOptions {
             ident: &self.setter_ident,
             field_ident: &self.field_ident,
             field_type: &self.field_type,
+            generic_into: self.setter_into,
             deprecation_notes: &self.deprecation_notes,
         }
     }

--- a/derive_builder/src/options/mod.rs
+++ b/derive_builder/src/options/mod.rs
@@ -36,6 +36,7 @@ pub struct OptionsBuilder<Mode> {
     setter_name: Option<String>,
     setter_vis: Option<syn::Visibility>,
     default_expression: Option<DefaultExpression>,
+    setter_into: Option<bool>,
     mode: Mode,
 }
 
@@ -56,6 +57,7 @@ impl<Mode> From<Mode> for OptionsBuilder<Mode> {
             setter_name: None,
             setter_vis: None,
             default_expression: None,
+            setter_into: None,
             mode: mode,
         }
     }
@@ -111,6 +113,12 @@ impl<Mode> OptionsBuilder<Mode> where
         ident: setter_public for setter_vis,
         desc: "setter visibility",
         map: |x: bool| { if x { syn::Visibility::Public } else { syn::Visibility::Inherited } },
+    }
+
+    impl_setter!{
+        ident: setter_into,
+        desc: "setter type conversion",
+        map: |x: bool| { x },
     }
 
     impl_setter!{
@@ -314,6 +322,9 @@ impl<Mode> OptionsBuilder<Mode> where
             "skip" => {
                 self.setter_enabled(false)
             },
+            "into" => {
+                self.setter_into(true)
+            }
             _ => {
                 panic!("Unknown setter option `{}` {}.", ident.as_ref(), self.where_diagnostics())
             }

--- a/derive_builder/src/options/mod.rs
+++ b/derive_builder/src/options/mod.rs
@@ -156,7 +156,7 @@ impl<Mode> OptionsBuilder<Mode> where
 
     /// e.g `private` in `#[builder(private)]`
     fn parse_builder_options_word(&mut self, ident: &syn::Ident) {
-        trace!("Parsing word `{:?}`", ident);
+        trace!("Parsing word `{}`", ident.as_ref());
         match ident.as_ref() {
             "public" => {
                 self.setter_public(true)
@@ -171,7 +171,7 @@ impl<Mode> OptionsBuilder<Mode> where
                 self.default_expression(DefaultExpression::Trait)
             },
             _ => {
-                panic!("Unknown option `{:?}`", ident)
+                panic!("Unknown option `{}`", ident.as_ref())
             }
         };
     }
@@ -179,7 +179,7 @@ impl<Mode> OptionsBuilder<Mode> where
     /// e.g `setter_prefix="with"` in `#[builder(setter_prefix="with")]`
     #[allow(non_snake_case)]
     fn parse_builder_options_nameValue(&mut self, ident: &syn::Ident, lit: &syn::Lit) {
-        trace!("Parsing named value `{:?}` = `{:?}`", ident, lit);
+        trace!("Parsing named value `{}` = `{:?}`", ident.as_ref(), lit);
         match ident.as_ref() {
             "setter_prefix" => {
                 let val = quote!(#lit);
@@ -264,7 +264,7 @@ impl<Mode> OptionsBuilder<Mode> where
 
     /// e.g `private` in `#[builder(setter(private))]`
     fn parse_setter_options_word(&mut self, ident: &syn::Ident) {
-        trace!("Setter Options - Parsing word `{:?}`", ident);
+        trace!("Setter Options - Parsing word `{}`", ident.as_ref());
         match ident.as_ref() {
             "public" => {
                 self.setter_public(true)
@@ -276,7 +276,7 @@ impl<Mode> OptionsBuilder<Mode> where
                 self.setter_enabled(false)
             },
             _ => {
-                panic!("Unknown setter option `{:?}`.", ident)
+                panic!("Unknown setter option `{}`.", ident.as_ref())
             }
         };
     }
@@ -284,7 +284,7 @@ impl<Mode> OptionsBuilder<Mode> where
     /// e.g `prefix="with"` in `#[builder(setter(prefix="with"))]`
     #[allow(non_snake_case)]
     fn parse_setter_options_nameValue(&mut self, ident: &syn::Ident, lit: &syn::Lit) {
-        trace!("Setter Options - Parsing named value `{:?}` = `{:?}`", ident, lit);
+        trace!("Setter Options - Parsing named value `{}` = `{:?}`", ident.as_ref(), lit);
         match ident.as_ref() {
             "prefix" => {
                 self.parse_setter_prefix(lit)

--- a/derive_builder/src/options/mod.rs
+++ b/derive_builder/src/options/mod.rs
@@ -27,8 +27,8 @@ pub fn field_options_from(f: syn::Field,
 /// Build `StructOptions` and `FieldOptions`.
 ///
 /// The difference between `StructOptions` and `FieldOptions` is expressed via a different `Mode`.
-#[derive(Default, Debug, Clone)]
-pub struct OptionsBuilder<Mode: OptionsBuilderMode> {
+#[derive(Debug, Clone)]
+pub struct OptionsBuilder<Mode> {
     builder_pattern: Option<BuilderPattern>,
     setter_enabled: Option<bool>,
     setter_prefix: Option<String>,
@@ -43,6 +43,20 @@ pub struct OptionsBuilder<Mode: OptionsBuilderMode> {
 pub trait OptionsBuilderMode {
     fn parse_builder_name(&mut self, lit: &syn::Lit);
     fn push_deprecation_note<T: Into<String>>(&mut self, x: T) -> &mut Self;
+}
+
+impl<Mode> From<Mode> for OptionsBuilder<Mode> {
+    fn from(mode: Mode) -> OptionsBuilder<Mode> {
+        OptionsBuilder {
+            builder_pattern: None,
+            setter_enabled: None,
+            setter_prefix: None,
+            setter_name: None,
+            setter_vis: None,
+            default_expression: None,
+            mode: mode,
+        }
+    }
 }
 
 impl<Mode> OptionsBuilder<Mode> where

--- a/derive_builder/src/options/mod.rs
+++ b/derive_builder/src/options/mod.rs
@@ -40,9 +40,11 @@ pub struct OptionsBuilder<Mode> {
 }
 
 /// Certain attributes need to be handled differently for `StructOptions` and `FieldOptions`.
-pub trait OptionsBuilderMode {
+pub trait OptionsBuilderMode: ::std::fmt::Debug {
     fn parse_builder_name(&mut self, lit: &syn::Lit);
     fn push_deprecation_note<T: Into<String>>(&mut self, x: T) -> &mut Self;
+    /// Provide a diagnostic _where_-clause for panics.
+    fn where_diagnostics(&self) -> String;
 }
 
 impl<Mode> From<Mode> for OptionsBuilder<Mode> {
@@ -59,43 +61,62 @@ impl<Mode> From<Mode> for OptionsBuilder<Mode> {
     }
 }
 
+macro_rules! impl_setter {
+    (
+        ident: $ident:ident,
+        desc: $desc:expr,
+        map: |$x:ident: $ty:ty| {$( $map:tt )*},
+    ) => {
+        impl_setter!{
+            ident: $ident for $ident,
+            desc: $desc,
+            map: |$x: $ty| {$( $map )*},
+        }
+    };
+    (
+        ident: $setter:ident for $field:ident,
+        desc: $desc:expr,
+        map: |$x:ident: $ty:ty| {$( $map:tt )*},
+    ) => {
+        fn $setter(&mut self, $x: $ty) -> &mut Self {
+            if let Some(ref current) = self.$field {
+                panic!("Failed to set {} to `{:?}` (already defined as `{:?}`) {}.",
+                    $desc,
+                    $x,
+                    current,
+                    self.where_diagnostics());
+            }
+            self.$field = Some({$( $map )*});
+            self
+        }
+    }
+}
+
 impl<Mode> OptionsBuilder<Mode> where
     Mode: OptionsBuilderMode
 {
-    fn setter_enabled(&mut self, x: bool) -> &mut Self {
-        if self.setter_enabled.is_some() {
-            warn!("Setter enabled already defined as `{:?}`, new value is `{:?}`.",
-                self.setter_enabled, x);
-        }
-        self.setter_enabled = Some(x);
-        self
+    impl_setter!{
+        ident: setter_enabled,
+        desc: "setter activation",
+        map: |x: bool| { x },
     }
 
-    fn builder_pattern(&mut self, x: BuilderPattern) -> &mut Self {
-        if self.builder_pattern.is_some() {
-            warn!("Setter pattern already defined as `{:?}`, new value is `{:?}`.",
-                self.builder_pattern, x);
-        }
-        self.builder_pattern = Some(x);
-        self
+    impl_setter!{
+        ident: builder_pattern,
+        desc: "builder pattern",
+        map: |x: BuilderPattern| { x },
     }
 
-    fn setter_public(&mut self, x: bool) -> &mut Self {
-        if self.setter_vis.is_some() {
-            warn!("Setter visibility already defined as `{:?}`, new value is `{:?}`.",
-                self.setter_vis, x);
-        }
-        self.setter_vis = Some(syn::Visibility::Public);
-        self
+    impl_setter!{
+        ident: setter_public for setter_vis,
+        desc: "setter visibility",
+        map: |x: bool| { if x { syn::Visibility::Public } else { syn::Visibility::Inherited } },
     }
 
-    fn default_expression(&mut self, x: DefaultExpression) -> &mut Self {
-        if self.default_expression.is_some() {
-            warn!("Default expression already defined as `{:?}`, new value is `{:?}`.",
-                self.default_expression, x);
-        }
-        self.default_expression = Some(x);
-        self
+    impl_setter!{
+        ident: default_expression,
+        desc: "default expression",
+        map: |x: DefaultExpression| { x },
     }
 
     pub fn parse_attributes<'a, T>(&mut self, attributes: T) -> &mut Self where
@@ -125,14 +146,13 @@ impl<Mode> OptionsBuilder<Mode> where
         match attr.value {
             // i.e. `#[builder(...)]`
             syn::MetaItem::List(ref _ident, ref nested_attrs) => {
-                self.setter_enabled(true);
                 self.parse_builder_options(nested_attrs);
                 return
             },
             syn::MetaItem::Word(_) |
             syn::MetaItem::NameValue(_, _) => {
                 error!("Expected MetaItem::List, found `{:?}`", attr.value);
-                panic!("Could not parse builder options.");
+                panic!("Could not parse builder options {}.", self.where_diagnostics());
             }
         }
     }
@@ -146,7 +166,9 @@ impl<Mode> OptionsBuilder<Mode> where
                 },
                 syn::NestedMetaItem::Literal(ref lit) => {
                     error!("Expected NestedMetaItem::MetaItem, found `{:?}`.", x);
-                    panic!("Could not parse builder option `{:?}`.", lit);
+                    panic!("Could not parse builder option `{:?}` {}.",
+                           lit,
+                           self.where_diagnostics());
                 }
             }
         }
@@ -179,13 +201,14 @@ impl<Mode> OptionsBuilder<Mode> where
                 self.setter_public(false)
             },
             "setter" => {
+                // setter implicitly enabled
                 self.setter_enabled(true)
             },
             "default" => {
                 self.default_expression(DefaultExpression::Trait)
             },
             _ => {
-                panic!("Unknown option `{}`", ident.as_ref())
+                panic!("Unknown option `{}` {}", ident.as_ref(), self.where_diagnostics())
             }
         };
     }
@@ -213,7 +236,7 @@ impl<Mode> OptionsBuilder<Mode> where
                 self.parse_default_expression(lit)
             },
             _ => {
-                panic!("Unknown option `{}`.", ident.as_ref())
+                panic!("Unknown option `{}` {}.", ident.as_ref(), self.where_diagnostics())
             }
         }
     }
@@ -228,10 +251,14 @@ impl<Mode> OptionsBuilder<Mode> where
         trace!("Parsing list `{}({:?})`", ident.as_ref(), nested);
         match ident.as_ref() {
             "setter" => {
-                self.parse_setter_options(nested)
+                self.parse_setter_options(nested);
+                // setter implicitly enabled
+                if self.setter_enabled.is_none() {
+                    self.setter_enabled(true);
+                }
             },
             _ => {
-                panic!("Unknown option `{}`.", ident.as_ref())
+                panic!("Unknown option `{}` {}.", ident.as_ref(), self.where_diagnostics())
             }
         }
     }
@@ -247,14 +274,12 @@ impl<Mode> OptionsBuilder<Mode> where
             match *x {
                 syn::NestedMetaItem::MetaItem(ref meta_item) => {
                     self.parse_setter_options_metaItem(meta_item);
-                    // setters implicitly enabled
-                    if self.setter_enabled.is_none() {
-                        self.setter_enabled(true);
-                    }
                 },
-                syn::NestedMetaItem::Literal(ref _lit) => {
-                    // setters explicitly enabled
-                    self.setter_enabled(true);
+                syn::NestedMetaItem::Literal(ref lit) => {
+                    error!("Expected NestedMetaItem::MetaItem, found `{:?}`.", x);
+                    panic!("Could not parse builder option `{:?}` {}.",
+                           lit,
+                           self.where_diagnostics());
                 }
             }
         }
@@ -290,7 +315,7 @@ impl<Mode> OptionsBuilder<Mode> where
                 self.setter_enabled(false)
             },
             _ => {
-                panic!("Unknown setter option `{}`.", ident.as_ref())
+                panic!("Unknown setter option `{}` {}.", ident.as_ref(), self.where_diagnostics())
             }
         };
     }
@@ -307,7 +332,7 @@ impl<Mode> OptionsBuilder<Mode> where
                 self.parse_setter_skip(lit)
             },
             _ => {
-                panic!("Unknown setter option `{}`.", ident.as_ref())
+                panic!("Unknown setter option `{}` {}.", ident.as_ref(), self.where_diagnostics())
             }
         }
     }
@@ -322,7 +347,7 @@ impl<Mode> OptionsBuilder<Mode> where
         trace!("Setter Options - Parsing list `{}({:?})`", ident.as_ref(), nested);
         match ident.as_ref() {
             _ => {
-                panic!("Unknown option `{}`.", ident.as_ref())
+                panic!("Unknown option `{}` {}.", ident.as_ref(), self.where_diagnostics())
             }
         }
     }
@@ -353,7 +378,7 @@ impl<Mode> OptionsBuilder<Mode> where
                 self.builder_pattern(BuilderPattern::Immutable)
             },
             _ => {
-                panic!("Unknown pattern value `{}`.", value)
+                panic!("Unknown pattern value `{}` {}.", value, self.where_diagnostics())
             }
         };
     }
@@ -361,6 +386,13 @@ impl<Mode> OptionsBuilder<Mode> where
     fn parse_setter_skip(&mut self, skip: &syn::Lit) {
         trace!("Parsing skip setter `{:?}`", skip);
         self.setter_enabled(!parse_lit_as_bool(skip).unwrap());
+    }
+
+    /// Provide a diagnostic _where_-clause for panics.
+    ///
+    /// Delegete to the `OptionsBuilderMode`.
+    fn where_diagnostics(&self) -> String {
+        self.mode.where_diagnostics()
     }
 }
 

--- a/derive_builder/src/options/struct_mode.rs
+++ b/derive_builder/src/options/struct_mode.rs
@@ -2,7 +2,7 @@ use syn;
 use options::{OptionsBuilder, OptionsBuilderMode, parse_lit_as_string, FieldMode, StructOptions};
 use derive_builder_core::DeprecationNotes;
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub struct StructMode {
     build_target_name: String,
     build_target_generics: syn::Generics,
@@ -17,6 +17,7 @@ impl OptionsBuilder<StructMode> {
     pub fn parse(ast: &syn::MacroInput) -> Self {
         trace!("Parsing struct `{}`.", ast.ident.as_ref());
 
+        // Note: Set `build_target_name` _before_ parsing attributes, for better diagnostics!
         let mut builder = Self::from(StructMode {
             build_target_name: ast.ident.as_ref().to_string(),
             build_target_generics: ast.generics.clone(),
@@ -43,6 +44,11 @@ impl OptionsBuilderMode for StructMode {
     fn push_deprecation_note<T: Into<String>>(&mut self, x: T) -> &mut Self {
         self.deprecation_notes.push(x.into());
         self
+    }
+
+    /// Provide a diagnostic _where_-clause for panics.
+    fn where_diagnostics(&self) -> String {
+        format!("on struct `{}`", self.build_target_name)
     }
 }
 

--- a/derive_builder/src/options/struct_mode.rs
+++ b/derive_builder/src/options/struct_mode.rs
@@ -60,6 +60,7 @@ impl From<OptionsBuilder<StructMode>> for (StructOptions, OptionsBuilder<FieldMo
             setter_name: None,
             setter_prefix: b.setter_prefix,
             setter_vis: b.setter_vis,
+            setter_into: b.setter_into,
             default_expression: b.default_expression,
             mode: FieldMode::default(),
         };

--- a/derive_builder/src/options/struct_options.rs
+++ b/derive_builder/src/options/struct_options.rs
@@ -20,7 +20,7 @@ pub struct StructOptions {
     /// e.g. if a deprecated attribute was used in `derive_builder`.
     pub deprecation_notes: DeprecationNotes,
     /// Number of fields on the target struct.
-    pub struct_len: usize,
+    pub struct_size_hint: usize,
 }
 
 impl StructOptions {
@@ -31,8 +31,8 @@ impl StructOptions {
             ident: &self.builder_ident,
             generics: Some(&self.generics),
             visibility: &self.builder_visibility,
-            fields: Vec::with_capacity(self.struct_len),
-            functions: Vec::with_capacity(self.struct_len),
+            fields: Vec::with_capacity(self.struct_size_hint),
+            functions: Vec::with_capacity(self.struct_size_hint),
             doc_comment: None,
             deprecation_notes: DeprecationNotes::default(),
         }
@@ -47,7 +47,7 @@ impl StructOptions {
             pattern: self.builder_pattern,
             target_ty: &self.build_target_ident,
             target_ty_generics: Some(ty_generics),
-            initializers: Vec::with_capacity(self.struct_len),
+            initializers: Vec::with_capacity(self.struct_size_hint),
             doc_comment: None,
         }
     }

--- a/derive_builder/tests/builder_name.rs
+++ b/derive_builder/tests/builder_name.rs
@@ -4,8 +4,8 @@ extern crate derive_builder;
 #[derive(Debug, PartialEq, Default, Builder, Clone)]
 #[builder(name="MyBuilder")]
 struct Lorem {
-    ipsum: String,
-    pub dolor: Option<String>,
+    ipsum: &'static str,
+    pub dolor: Option<&'static str>,
     pub sit: i32,
     amet: bool,
 }
@@ -20,7 +20,7 @@ fn panic_if_uninitialized() {
 fn builder() {
     let x: Lorem = MyBuilder::default()
         .ipsum("lorem")
-        .dolor(Some("dolor".into()))
+        .dolor(Some("dolor"))
         .sit(42)
         .amet(true)
         .build()
@@ -28,8 +28,8 @@ fn builder() {
 
     assert_eq!(x,
                Lorem {
-                   ipsum: "lorem".into(),
-                   dolor: Some("dolor".into()),
+                   ipsum: "lorem",
+                   dolor: Some("dolor"),
                    sit: 42,
                    amet: true,
                });

--- a/derive_builder/tests/custom_default.rs
+++ b/derive_builder/tests/custom_default.rs
@@ -30,7 +30,7 @@ mod field_level {
     #[test]
     fn custom_default() {
         let x = LoremBuilder::default()
-            .required("ipsum")
+            .required("ipsum".to_string())
             .build()
             .unwrap();
 
@@ -46,10 +46,10 @@ mod field_level {
     #[test]
     fn builder() {
         let x = LoremBuilder::default()
-            .required("ipsum")
-            .explicit_default("lorem")
-            .escaped_default("dolor")
-            .raw_default("sit")
+            .required("ipsum".to_string())
+            .explicit_default("lorem".to_string())
+            .escaped_default("dolor".to_string())
+            .raw_default("sit".to_string())
             .build()
             .unwrap();
 
@@ -93,10 +93,10 @@ mod struct_level {
     #[test]
     fn builder() {
         let x = LoremBuilder::default()
-            .implicit_default("ipsum")
-            .explicit_default("lorem")
-            .escaped_default("dolor")
-            .raw_default("sit")
+            .implicit_default("ipsum".to_string())
+            .explicit_default("lorem".to_string())
+            .escaped_default("dolor".to_string())
+            .raw_default("sit".to_string())
             .build()
             .unwrap();
 

--- a/derive_builder/tests/generic_structs.rs
+++ b/derive_builder/tests/generic_structs.rs
@@ -5,7 +5,7 @@ extern crate derive_builder;
 struct GenLorem<T>
     where T: std::clone::Clone
 {
-    ipsum: String,
+    ipsum: &'static str,
     pub dolor: T,
 }
 
@@ -13,7 +13,7 @@ struct GenLorem<T>
 struct GenLorem2<T>
     where T: std::clone::Clone
 {
-    ipsum: String,
+    ipsum: &'static str,
     pub dolor: T,
 }
 

--- a/derive_builder/tests/setter_into.rs
+++ b/derive_builder/tests/setter_into.rs
@@ -1,0 +1,40 @@
+#[macro_use]
+extern crate derive_builder;
+
+#[derive(Debug, PartialEq, Default, Builder, Clone)]
+struct Lorem {
+    #[builder(setter(into))]
+    foo: String,
+}
+
+#[derive(Debug, PartialEq, Default, Builder, Clone)]
+#[builder(setter(into))]
+struct Ipsum {
+    foo: u32,
+}
+
+#[test]
+fn generic_field() {
+    let x = LoremBuilder::default()
+        .foo("foo")
+        .build()
+        .unwrap();
+
+    assert_eq!(x,
+               Lorem {
+                   foo: "foo".to_string(),
+               });
+}
+
+#[test]
+fn generic_struct() {
+    let x = IpsumBuilder::default()
+        .foo(42u8)
+        .build()
+        .unwrap();
+
+    assert_eq!(x,
+               Ipsum {
+                   foo: 42u32,
+               });
+}

--- a/derive_builder/tests/setter_prefix.rs
+++ b/derive_builder/tests/setter_prefix.rs
@@ -4,22 +4,22 @@ extern crate derive_builder;
 #[derive(Debug, PartialEq, Default, Builder, Clone)]
 #[builder(setter(prefix="with"))]
 struct Lorem {
-    ipsum: String,
+    ipsum: &'static str,
     #[builder(setter(prefix="set"))]
-    pub dolor: Option<String>,
+    pub dolor: &'static str,
 }
 
 #[test]
 fn prefixed_setters() {
     let x = LoremBuilder::default()
         .with_ipsum("ipsum")
-        .set_dolor(Some("dolor".into()))
+        .set_dolor("dolor")
         .build()
         .unwrap();
 
     assert_eq!(x,
                Lorem {
-                   ipsum: "ipsum".into(),
-                   dolor: Some("dolor".into()),
+                   ipsum: "ipsum",
+                   dolor: "dolor",
                });
 }

--- a/derive_builder/tests/setter_visibility.rs
+++ b/derive_builder/tests/setter_visibility.rs
@@ -3,7 +3,7 @@ extern crate derive_builder;
 
 pub mod foo {
     #[derive(Debug, PartialEq, Default, Builder, Clone)]
-    #[builder(private)]
+    #[builder(private, setter(into))]
     pub struct Lorem {
         pub private: String,
         #[builder(public)]
@@ -11,7 +11,7 @@ pub mod foo {
     }
 
     #[derive(Debug, PartialEq, Default, Builder, Clone)]
-    #[builder(public)]
+    #[builder(public, setter(into))]
     pub struct Ipsum {
         #[builder(private)]
         pub private: String,

--- a/derive_builder/tests/skip-setter.rs
+++ b/derive_builder/tests/skip-setter.rs
@@ -20,6 +20,8 @@ struct SetterOptIn {
     setter_present_by_explicit_opt_in: u32,
     #[builder(setter)]
     setter_present_by_shorthand_opt_in: u32,
+    #[builder(setter(prefix="set"))]
+    setter_present_by_shorthand_opt_in_2: u32,
 }
 
 // compile test
@@ -56,6 +58,7 @@ fn setter_opt_in() {
     let x: SetterOptIn = SetterOptInBuilder::default()
         .setter_present_by_explicit_opt_in(47u32)
         .setter_present_by_shorthand_opt_in(11u32)
+        .set_setter_present_by_shorthand_opt_in_2(815u32)
         .build()
         .unwrap();
 
@@ -64,5 +67,6 @@ fn setter_opt_in() {
                    setter_skipped_by_shorthand_default: 0,
                    setter_present_by_explicit_opt_in: 47,
                    setter_present_by_shorthand_opt_in: 11,
+                   setter_present_by_shorthand_opt_in_2: 815,
                });
 }


### PR DESCRIPTION
This seems more idiomatic to me:
- setter conversions are now off by default, you can opt-into via `#[builder(setter(into))]`

=> breaking change — indeed I had to adapt a lot of testcases, which implicitly relied on generic setters.

cc @killercup in case you want to give feedback. :-)

---
PS: based on pr #57, so only the last commit is relevant here.