### PR TITLE
feature flag `logging`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ rust:
 matrix:
   include:
     - rust: nightly
-      env: JOB=build CARGO_FEATURES=compiletests
+      env: JOB=build CARGO_FEATURES="compiletests logging"
     - rust: nightly
       env: JOB=style_check
   allow_failures:

--- a/derive_builder/CHANGELOG.md
+++ b/derive_builder/CHANGELOG.md
@@ -13,6 +13,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
   please use `#[builder(setter(prefix="with"))]` instead
 - setter conversions are now off by default, you can opt-into via
   `#[builder(setter(into))]`
+- logging is behind a feature flag. To activate it, please add
+  `features = ["logging"]` to the dependency in `Cargo.toml`. Then you can use
+  it like: `RUST_LOG=derive_builder=trace cargo test`.
 
 ### Fixed
 - use full path for result #39

--- a/derive_builder/Cargo.toml
+++ b/derive_builder/Cargo.toml
@@ -21,17 +21,20 @@ travis-ci = { repository = "colin-kiegel/rust-derive-builder" }
 [lib]
 proc-macro = true
 
+[features]
+logging = [ "log", "env_logger", "derive_builder_core/logging" ]
+
 [dependencies]
 syn = "0.11"
 quote = "0.3"
-log = "0.3"
-env_logger = "0.4"
+log = { version = "0.3", optional = true }
+env_logger = { version = "0.4", optional = true }
 derive_builder_core = { version = "0.1", path = "../derive_builder_core" }
 
 [build-dependencies]
 skeptic = "0.7"
-log = "0.3"
-env_logger = "0.4"
+log = { version = "0.3", optional = true }
+env_logger = { version = "0.4", optional = true }
 
 [dev-dependencies]
 skeptic = "0.7"

--- a/derive_builder/README.md
+++ b/derive_builder/README.md
@@ -92,7 +92,7 @@ with [cargo-edit](https://github.com/killercup/cargo-edit):
 * **Setter visibility**: You can opt into private setter by preceding your struct with `#[builder(private)]`.
 * **Setter type conversions**: With ``#[builder(setter(into))]`, setter methods will be generic over the input types – you can then supply every argument that implements the [`Into`][into] trait for the field type.
 * **Generic structs**: Are also supported, but you **must not** use a type parameter named `VALUE`, if you also activate setter type conversions.
-* **Logging**: If anything works unexpectedly you can enable detailed logs by setting this environment variable before calling cargo `RUST_LOG=derive_builder=trace`.
+* **Logging**: If anything works unexpectedly you can enable detailed logs in two steps. First, add `features = ["logging"]` to the `derive_builder` dependency in `Cargo.toml`. Second, set this environment variable before calling cargo `RUST_LOG=derive_builder=trace`.
 
 For more information and examples please take a look at our [documentation][doc].
 

--- a/derive_builder/build.rs
+++ b/derive_builder/build.rs
@@ -1,10 +1,19 @@
+#[cfg(feature = "logging")]
 #[macro_use]
 extern crate log;
+#[cfg(feature = "logging")]
 extern crate env_logger;
 extern crate skeptic;
 
+#[cfg(not(feature = "logging"))]
+#[macro_use]
+mod log_disabled {
+    include!("src/log_disabled.rs");
+}
+
 fn main() {
     println!("INFO: Run with `RUST_LOG=build_script_build=trace` for debug information.");
+    #[cfg(feature = "logging")]
     env_logger::init().unwrap();
 
     let mut files = generate_doc_tpl_tests().unwrap();

--- a/derive_builder/src/lib.rs
+++ b/derive_builder/src/lib.rs
@@ -362,9 +362,13 @@
 //!
 //! ## Debugging Info
 //!
-//! If you experience any problems during compilation, you can enable additional debug output
-//! by setting the environment variable `RUST_LOG=derive_builder=trace` before you call `cargo`
-//! or `rustc`. Example: `env RUST_LOG=derive_builder=trace cargo test`.
+//! If you experience any problems during compilation, you can enable additional debug output in
+//! two steps:
+//!
+//! 1. Add `features = ["logging"]` to the `derive_builder` dependency in `Cargo.toml`.
+//! 2. Set this environment variable before calling cargo or rustc `RUST_LOG=derive_builder=trace`.
+//!
+//! Example: `env RUST_LOG=derive_builder=trace cargo test`.
 //!
 //! ## Report Issues and Ideas
 //!
@@ -383,22 +387,30 @@ extern crate proc_macro;
 extern crate syn;
 #[macro_use]
 extern crate quote;
+#[cfg(feature = "logging")]
 #[macro_use]
 extern crate log;
+#[cfg(feature = "logging")]
 extern crate env_logger;
 extern crate derive_builder_core;
 
+#[cfg(not(feature = "logging"))]
+#[macro_use]
+mod log_disabled;
 mod options;
 
 use proc_macro::TokenStream;
+#[cfg(feature = "logging")]
 use std::sync::{Once, ONCE_INIT};
 use options::{struct_options_from, field_options_from};
 
+#[cfg(feature = "logging")]
 static INIT_LOGGER: Once = ONCE_INIT;
 
 #[doc(hidden)]
 #[proc_macro_derive(Builder, attributes(builder))]
 pub fn derive(input: TokenStream) -> TokenStream {
+    #[cfg(feature = "logging")]
     INIT_LOGGER.call_once(|| {
         env_logger::init().unwrap();
     });

--- a/derive_builder/src/log_disabled.rs
+++ b/derive_builder/src/log_disabled.rs
@@ -1,0 +1,1 @@
+../../derive_builder_core/src/log_disabled.rs

--- a/derive_builder_core/Cargo.toml
+++ b/derive_builder_core/Cargo.toml
@@ -12,10 +12,13 @@ documentation = "https://docs.rs/derive_builder_core"
 license = "MIT/Apache-2.0"
 readme = "README.md"
 
+[features]
+logging = [ "log" ]
+
 [badges]
 travis-ci = { repository = "colin-kiegel/rust-derive-builder" }
 
 [dependencies]
 syn = "0.11"
 quote = "0.3"
-log = "0.3"
+log = { version = "0.3", optional = true }

--- a/derive_builder_core/src/lib.rs
+++ b/derive_builder_core/src/lib.rs
@@ -27,9 +27,13 @@ extern crate proc_macro;
 extern crate syn;
 #[macro_use]
 extern crate quote;
+#[cfg(feature = "logging")]
 #[macro_use]
 extern crate log;
 
+#[cfg(not(feature = "logging"))]
+#[macro_use]
+mod log_disabled;
 mod build_method;
 mod builder_field;
 mod builder;

--- a/derive_builder_core/src/log_disabled.rs
+++ b/derive_builder_core/src/log_disabled.rs
@@ -6,28 +6,28 @@ macro_rules! log_enabled {
     ($( $x:tt )*) => { false }
 }
 
-// delegate to format and throw away the result to avoid `unused variable` lints.
+// delegate to format_args and throw away the result to avoid `unused variable` lints.
 // The compiler should be able to optimize this away.
 macro_rules! debug {
-    ($( $x:tt )*) => { format!($( $x )*); }
+    ($( $x:tt )*) => { format_args!($( $x )*); }
 }
 
 macro_rules! error {
-    ($( $x:tt )*) => { format!($( $x )*); }
+    ($( $x:tt )*) => { format_args!($( $x )*); }
 }
 
 macro_rules! info {
-    ($( $x:tt )*) => { format!($( $x )*); }
+    ($( $x:tt )*) => { format_args!($( $x )*); }
 }
 
 macro_rules! log {
-    ($( $x:tt )*) => { format!($( $x )*); }
+    ($( $x:tt )*) => { format_args!($( $x )*); }
 }
 
 macro_rules! trace {
-    ($( $x:tt )*) => { format!($( $x )*); }
+    ($( $x:tt )*) => { format_args!($( $x )*); }
 }
 
 macro_rules! warn {
-    ($( $x:tt )*) => { format!($( $x )*); }
+    ($( $x:tt )*) => { format_args!($( $x )*); }
 }

--- a/derive_builder_core/src/log_disabled.rs
+++ b/derive_builder_core/src/log_disabled.rs
@@ -1,0 +1,33 @@
+/// Overrides for https://docs.rs/log/#macros
+///
+/// Source shared by `derive_builder_core` and `derive_builder` via symlink.
+
+macro_rules! log_enabled {
+    ($( $x:tt )*) => { false }
+}
+
+// delegate to format and throw away the result to avoid `unused variable` lints.
+// The compiler should be able to optimize this away.
+macro_rules! debug {
+    ($( $x:tt )*) => { format!($( $x )*); }
+}
+
+macro_rules! error {
+    ($( $x:tt )*) => { format!($( $x )*); }
+}
+
+macro_rules! info {
+    ($( $x:tt )*) => { format!($( $x )*); }
+}
+
+macro_rules! log {
+    ($( $x:tt )*) => { format!($( $x )*); }
+}
+
+macro_rules! trace {
+    ($( $x:tt )*) => { format!($( $x )*); }
+}
+
+macro_rules! warn {
+    ($( $x:tt )*) => { format!($( $x )*); }
+}

--- a/derive_builder_test/Cargo.toml
+++ b/derive_builder_test/Cargo.toml
@@ -10,6 +10,7 @@ path = "src/lib.rs"
 
 [features]
 compiletests = ["compiletest_rs"]
+logging = [ "derive_builder/logging" ]
 
 [dependencies]
 derive_builder = { path = "../derive_builder" }


### PR DESCRIPTION
- put logging behind a feature flag to improve compile time,
  since we have unit tests, this is far less important than before.

**Open Question**: I wonder how I should adapt the [travis configuration](https://github.com/colin-kiegel/rust-derive-builder/blob/feature/logging_optional/.travis.yml#L53-L55) to test for features.
- Would it be sufficient to just test `--features "compiletests logging"` on nightly?
- Or should I have one run with default features, and one with full features (except dev_nightly) on each rust release?

cc @killercup in case you want to give feedback. :-)