### PR TITLE
Documentation-related enhancements

### DIFF
--- a/derive_builder/src/doc_tpl/builder_struct.md
+++ b/derive_builder/src/doc_tpl/builder_struct.md
@@ -1,1 +1,1 @@
-Builder for `{struct_name}`.
+Builder for [`{struct_name}`](struct.{struct_name}.html).

--- a/derive_builder/src/options/mod.rs
+++ b/derive_builder/src/options/mod.rs
@@ -1,3 +1,16 @@
+//! Types and functions for parsing attribute options.
+//!
+//! Attribute parsing occurs in two stages:
+//!
+//! 1. Builder options on the struct are parsed into `OptionsBuilder<StructMode>`.
+//! 1. The `OptionsBuilder<StructMode>` instance is converted into a starting point for the 
+//!    per-field options (`OptionsBuilder<FieldMode>`) and the finished struct-level config,
+//!    called `StructOptions`.
+//! 1. Each struct field is parsed, with discovered attributes overriding or augmenting the 
+//!    options specified at the struct level. This creates one `OptionsBuilder<FieldMode>` per
+//!    struct field on the input/target type. Once complete, these get converted into
+//!    `FieldOptions` instances.
+
 use syn;
 use derive_builder_core::BuilderPattern;
 


### PR DESCRIPTION
Two minor things (both vaguely docs-related).

1. Made the builder's documentation include a link to the target type. Since we know we're in the same module as the target type, we can do this reliably with a relative URL.
1. Added a module-level doc comment to `derive_builder::options` to help others understand what's happening. @faern, let me know if this helps.