### PR TITLE
Improved type param bound expressions (#91)

### DIFF
--- a/derive_builder/CHANGELOG.md
+++ b/derive_builder/CHANGELOG.md
@@ -4,6 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
 - perform pre-build validation via `#[builder(build_fn(validate="path::to::fn"))]`
+- builder derivation acts like `#[derive(Clone)]` for generic structs.
 
 ## [0.4.5] - 2017-04-25
 

--- a/derive_builder/CHANGELOG.md
+++ b/derive_builder/CHANGELOG.md
@@ -3,7 +3,12 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## Unreleased
-- builder derivation acts like `#[derive(Clone)]` for generic structs.
+
+### Fixed
+- for generic structs, apply the `T: Clone` type bound in builder impl
+  instead of struct definition #91
+- only emit the `T: Clone` type bound when it is actually needed, i.e.
+  mutable/immutable pattern, but not owned pattern.
 
 ## [0.4.6] - 2017-04-26
 

--- a/derive_builder/src/lib.rs
+++ b/derive_builder/src/lib.rs
@@ -484,8 +484,6 @@
 //!
 //! - Tuple structs and unit structs are not supported as they have no field
 //!   names.
-//! - Generic structs need the boundary `where T: std::clone::Clone` if
-//!   used in combination with the immutable/mutable pattern
 //! - Generic setters introduce a type parameter `VALUE: Into<_>`. Therefore you can't use
 //!  `VALUE` as a type parameter on a generic struct in combination with generic setters.
 //! - The `try_setter` attribute and `owned` builder pattern are not compatible in practice;

--- a/derive_builder/src/options/struct_mode.rs
+++ b/derive_builder/src/options/struct_mode.rs
@@ -1,7 +1,7 @@
 use syn;
 use options::{OptionsBuilder, OptionsBuilderMode, parse_lit_as_string, parse_lit_as_bool,
               parse_lit_as_path, FieldMode, StructOptions};
-use derive_builder_core::{BuilderPattern, DeprecationNotes, Bindings};
+use derive_builder_core::{DeprecationNotes, Bindings};
 
 #[derive(Debug, Clone)]
 pub struct StructMode {
@@ -260,7 +260,6 @@ impl From<OptionsBuilder<StructMode>> for (StructOptions, OptionsBuilder<FieldMo
         let bindings = Bindings {
             no_std: b.no_std.unwrap_or(false)
         };
-        let impl_generics = add_generic_bounds(&pattern, &bindings, m.build_target_generics.clone());
 
         let struct_options = StructOptions {
             build_fn_enabled: m.build_fn_enabled.unwrap_or(true),
@@ -276,7 +275,6 @@ impl From<OptionsBuilder<StructMode>> for (StructOptions, OptionsBuilder<FieldMo
             derives: m.derive_traits.unwrap_or_default(),
             deprecation_notes: m.deprecation_notes,
             generics: m.build_target_generics,
-            inherent_generics: impl_generics,
             struct_size_hint: m.struct_size_hint,
             bindings: bindings,
             default_expression: struct_default_expression,
@@ -285,26 +283,4 @@ impl From<OptionsBuilder<StructMode>> for (StructOptions, OptionsBuilder<FieldMo
 
         (struct_options, field_defaults)
     }
-}
-
-#[allow(dead_code)]
-fn add_generic_bounds(pattern: &BuilderPattern,
-                      bindings: &Bindings,
-                      mut generics: syn::Generics)
-                      -> syn::Generics {
-    if !pattern.requires_clone() {
-        return generics;
-    }
-
-    for mut typ in generics.ty_params.iter_mut() {
-        typ.bounds.push(syn::TyParamBound::Trait(
-            syn::PolyTraitRef {
-                trait_ref: syn::parse_path(bindings.clone_trait().as_str()).unwrap(),
-                bound_lifetimes: vec![],
-            },
-            syn::TraitBoundModifier::None
-        ))
-    }
-
-    generics
 }

--- a/derive_builder/src/options/struct_mode.rs
+++ b/derive_builder/src/options/struct_mode.rs
@@ -1,6 +1,7 @@
 use syn;
-use options::{OptionsBuilder, OptionsBuilderMode, parse_lit_as_string, parse_lit_as_bool, parse_lit_as_path, FieldMode, StructOptions};
-use derive_builder_core::{DeprecationNotes, Bindings};
+use options::{OptionsBuilder, OptionsBuilderMode, parse_lit_as_string, parse_lit_as_bool,
+              parse_lit_as_path, FieldMode, StructOptions};
+use derive_builder_core::{BuilderPattern, DeprecationNotes, Bindings};
 
 #[derive(Debug, Clone)]
 pub struct StructMode {
@@ -48,31 +49,31 @@ impl StructMode {
         desc: "builder name",
         map: |x: String| { x },
     }
-    
+
     impl_setter!{
         ident: build_fn_name,
         desc: "build function name",
         map: |x: String| { x },
     }
-    
+
     impl_setter!{
         ident: build_fn_enabled,
         desc: "build function enabled",
         map: |x: bool| { x },
     }
-    
+
     impl_setter!{
         ident: validate_fn,
         desc: "validator function path",
         map: |x: syn::Path| { x },
     }
-    
+
     impl_setter!{
         ident: derive_traits,
         desc: "derive traits",
         map: |x: Vec<syn::Ident>| { x },
     }
-    
+
     #[allow(non_snake_case)]
     fn parse_build_fn_options_metaItem(&mut self, meta_item: &syn::MetaItem) {
         trace!("Build Method Options - Parsing MetaItem `{:?}`.", meta_item);
@@ -88,7 +89,7 @@ impl StructMode {
             }
         }
     }
-    
+
     #[allow(non_snake_case)]
     fn parse_build_fn_options_nameValue(&mut self, ident: &syn::Ident, lit: &syn::Lit) {
         trace!("Build fn Options - Parsing named value `{}` = `{:?}`", ident.as_ref(), lit);
@@ -107,7 +108,7 @@ impl StructMode {
             }
         }
     }
-    
+
     /// e.g `private` in `#[builder(build_fn(private))]`
     fn parse_build_fn_options_word(&mut self, ident: &syn::Ident) {
         trace!("Setter Options - Parsing word `{}`", ident.as_ref());
@@ -120,13 +121,9 @@ impl StructMode {
             }
         };
     }
-    
+
     #[allow(non_snake_case)]
-    fn parse_build_fn_options_list(
-        &mut self,
-        ident: &syn::Ident,
-        nested: &[syn::NestedMetaItem]
-    ) {
+    fn parse_build_fn_options_list(&mut self, ident: &syn::Ident, nested: &[syn::NestedMetaItem]) {
         trace!("Build fn Options - Parsing list `{}({:?})`", ident.as_ref(), nested);
         match ident.as_ref() {
             _ => {
@@ -134,18 +131,18 @@ impl StructMode {
             }
         }
     }
-    
+
     fn parse_build_fn_name(&mut self, lit: &syn::Lit) {
         trace!("Parsing build function name `{:?}`", lit);
         let value = parse_lit_as_string(lit).unwrap();
         self.build_fn_name(value.clone())
     }
-    
+
     #[allow(dead_code,unused_variables)]
     fn parse_build_fn_skip(&mut self, skip: &syn::Lit) {
         self.build_fn_enabled(!parse_lit_as_bool(skip).unwrap());
     }
-    
+
     fn parse_build_fn_validate(&mut self, lit: &syn::Lit) {
         trace!("Parsing build function validate path `{:?}`", lit);
         let value = parse_lit_as_path(lit).unwrap();
@@ -159,7 +156,7 @@ impl OptionsBuilderMode for StructMode {
         let value = parse_lit_as_string(name).unwrap();
         self.builder_name(value.clone());
     }
-    
+
     fn parse_build_fn_options(&mut self, nested: &[syn::NestedMetaItem]) {
         for x in nested {
             match *x {
@@ -182,13 +179,13 @@ impl OptionsBuilderMode for StructMode {
         let where_diag = self.where_diagnostics();
         for x in nested {
             match *x {
-                // We don't allow name-value pairs or further nesting here, so
-                // only look for words.
+        // We don't allow name-value pairs or further nesting here, so
+        // only look for words.
                 syn::NestedMetaItem::MetaItem(syn::MetaItem::Word(ref tr)) => {
                     match tr.as_ref() {
                         "Default" | "Clone" => { self.push_deprecation_note(
                             format!("The `Default` and `Clone` traits are automatically added to all \
-                            builders; explicitly deriving them is unnecessary ({})", where_diag)); 
+                            builders; explicitly deriving them is unnecessary ({})", where_diag));
                         },
                         _ => traits.push(tr.clone())
                     }
@@ -233,7 +230,7 @@ impl From<OptionsBuilder<StructMode>> for (StructOptions, OptionsBuilder<FieldMo
                 `field(<vis>)` to the builder attribute on the struct. (Found {})",
                 where_diagnostics));
         }
-        
+
         #[cfg(feature = "struct_default")]
         let (field_default_expression, struct_default_expression) = (None, b.default_expression);
         #[cfg(not(feature = "struct_default"))]
@@ -259,6 +256,12 @@ impl From<OptionsBuilder<StructMode>> for (StructOptions, OptionsBuilder<FieldMo
 
         let m = b.mode;
 
+        let pattern = b.builder_pattern.unwrap_or_default();
+        let bindings = Bindings {
+            no_std: b.no_std.unwrap_or(false)
+        };
+        let impl_generics = add_generic_bounds(&pattern, &bindings, m.build_target_generics.clone());
+
         let struct_options = StructOptions {
             build_fn_enabled: m.build_fn_enabled.unwrap_or(true),
             build_fn_name: syn::Ident::new(
@@ -268,19 +271,40 @@ impl From<OptionsBuilder<StructMode>> for (StructOptions, OptionsBuilder<FieldMo
                 m.builder_name.unwrap_or(format!("{}Builder", m.build_target_name))
             ),
             builder_visibility: m.builder_vis.unwrap_or(m.build_target_vis),
-            builder_pattern: b.builder_pattern.unwrap_or_default(),
+            builder_pattern: pattern,
             build_target_ident: syn::Ident::new(m.build_target_name),
             derives: m.derive_traits.unwrap_or_default(),
             deprecation_notes: m.deprecation_notes,
             generics: m.build_target_generics,
+            inherent_generics: impl_generics,
             struct_size_hint: m.struct_size_hint,
-            bindings: Bindings {
-                no_std: b.no_std.unwrap_or(false),
-            },
+            bindings: bindings,
             default_expression: struct_default_expression,
             validate_fn: m.validate_fn,
         };
 
         (struct_options, field_defaults)
     }
+}
+
+#[allow(dead_code)]
+fn add_generic_bounds(pattern: &BuilderPattern,
+                      bindings: &Bindings,
+                      mut generics: syn::Generics)
+                      -> syn::Generics {
+    if !pattern.requires_clone() {
+        return generics;
+    }
+
+    for mut typ in generics.ty_params.iter_mut() {
+        typ.bounds.push(syn::TyParamBound::Trait(
+            syn::PolyTraitRef {
+                trait_ref: syn::parse_path(bindings.clone_trait().as_str()).unwrap(),
+                bound_lifetimes: vec![],
+            },
+            syn::TraitBoundModifier::None
+        ))
+    }
+
+    generics
 }

--- a/derive_builder/src/options/struct_options.rs
+++ b/derive_builder/src/options/struct_options.rs
@@ -22,9 +22,6 @@ pub struct StructOptions {
     pub build_target_ident: syn::Ident,
     /// Represents lifetimes and type parameters attached to the declaration of items.
     pub generics: syn::Generics,
-    /// Represents lifetimes and type parameters attached to the `impl` 
-    /// block for the builder.
-    pub inherent_generics: syn::Generics,
     /// Emit deprecation notes to the user,
     /// e.g. if a deprecated attribute was used in `derive_builder`.
     pub deprecation_notes: DeprecationNotes,
@@ -45,14 +42,15 @@ impl StructOptions {
         Builder {
             enabled: true,
             ident: &self.builder_ident,
+            pattern: self.builder_pattern,
             derives: &self.derives,
             generics: Some(&self.generics),
-            impl_generics: Some(self.inherent_generics.split_for_impl().0),
             visibility: &self.builder_visibility,
             fields: Vec::with_capacity(self.struct_size_hint),
             functions: Vec::with_capacity(self.struct_size_hint),
             doc_comment: None,
             deprecation_notes: self.deprecation_notes.clone(),
+            bindings: self.bindings,
         }
     }
     /// Returns a `BuildMethod` according to the options.

--- a/derive_builder/src/options/struct_options.rs
+++ b/derive_builder/src/options/struct_options.rs
@@ -21,9 +21,10 @@ pub struct StructOptions {
     /// Target struct name.
     pub build_target_ident: syn::Ident,
     /// Represents lifetimes and type parameters attached to the declaration of items.
-    ///
-    /// We assume that this is identical for the builder and its build target.
     pub generics: syn::Generics,
+    /// Represents lifetimes and type parameters attached to the `impl` 
+    /// block for the builder.
+    pub inherent_generics: syn::Generics,
     /// Emit deprecation notes to the user,
     /// e.g. if a deprecated attribute was used in `derive_builder`.
     pub deprecation_notes: DeprecationNotes,
@@ -46,6 +47,7 @@ impl StructOptions {
             ident: &self.builder_ident,
             derives: &self.derives,
             generics: Some(&self.generics),
+            impl_generics: Some(self.inherent_generics.split_for_impl().0),
             visibility: &self.builder_visibility,
             fields: Vec::with_capacity(self.struct_size_hint),
             functions: Vec::with_capacity(self.struct_size_hint),

--- a/derive_builder/tests/bounds_generation.rs
+++ b/derive_builder/tests/bounds_generation.rs
@@ -1,0 +1,55 @@
+#[macro_use]
+extern crate derive_builder;
+
+/// A struct that deliberately doesn't implement `Clone`.
+#[derive(Debug, Default, PartialEq, Eq)]
+pub struct Dolor(String);
+
+/// Notice that this type derives Builder without disallowing
+/// `Lorem<Dolor>`.
+#[derive(Debug, Clone, Builder, PartialEq, Eq)]
+#[builder(field(private), setter(into))]
+pub struct Lorem<T> {
+    ipsum: T,
+}
+
+fn make_default_lorem<T: Default>() -> Lorem<T> {
+    Lorem {
+        ipsum: Default::default()
+    }
+}
+
+fn make_u16_lorem(v: u16) -> Lorem<u16> {
+    Lorem {
+        ipsum: v
+    }
+}
+
+fn make_dolor_lorem(v: Dolor) -> Lorem<Dolor> {
+    Lorem {
+        ipsum: v
+    }
+}
+
+fn build_u16_lorem(v: u16) -> Lorem<u16> {
+    LoremBuilder::default()
+        .ipsum(v)
+        .build()
+        .unwrap()
+}
+
+#[test]
+fn u16_lorems() {
+    assert_eq!(make_u16_lorem(10), build_u16_lorem(10));
+}
+
+#[test]
+fn dolor_lorems() {
+    assert_eq!(make_default_lorem(), make_dolor_lorem(Dolor::default()));
+}
+
+#[test]
+fn type_inference() {
+    assert_eq!(LoremBuilder::<String>::default().ipsum("".to_string()).build().unwrap(), 
+               make_default_lorem());
+}

--- a/derive_builder_core/src/options.rs
+++ b/derive_builder_core/src/options.rs
@@ -3,7 +3,7 @@
 ///
 /// It can also be generalized to methods with different parameter sets and return types,
 /// e.g. the `build()` method.
-#[derive(PartialEq, Debug, Clone, Copy)]
+#[derive(PartialEq, Eq, Debug, Clone, Copy)]
 pub enum BuilderPattern {
     /// E.g. `fn bar(self, bar: Bar) -> Self`.
     Owned,

--- a/derive_builder_core/src/options.rs
+++ b/derive_builder_core/src/options.rs
@@ -19,6 +19,14 @@ pub enum BuilderPattern {
     Immutable,
 }
 
+impl BuilderPattern {
+    /// Returns true if this style of builder needs to be able to clone its
+    /// fields during the `build` method.
+    pub fn requires_clone(&self) -> bool {
+        *self != BuilderPattern::Owned
+    }
+}
+
 /// Defaults to `Mutable`.
 impl Default for BuilderPattern {
     fn default() -> BuilderPattern {


### PR DESCRIPTION
This addresses #91 for the `Clone` trait using the same principles as the built-in `#[derive(Clone)]` implementation. It's sitting on top of #85, so a diff against that branch may be more useful for seeing the scope of this change. 

@colin-kiegel, I'm not 100% happy with the split between `derive_builder` and `derive_builder_core` at the moment. The `StructOptions` has to pass some of the generics twice or else the generated code won't compile. At the moment that's easy to uphold, but I'm wondering if it would be better to pass `additional_bounds` to `derive_builder_core::Builder` and have it assemble the correct generics internally.

I deliberately didn't put anything about this in `README.md` - I think that the behavior after the PR is more "normal" than the current behavior, so trying to explain it would be confusing.