### PR TITLE
Disable derive clone on owned pattern

### DIFF
--- a/derive_builder/CHANGELOG.md
+++ b/derive_builder/CHANGELOG.md
@@ -2,6 +2,12 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+
+### Changed
+- `Clone` is no longer derived on a builder using the owned pattern unless it
+  has a field override that uses the mutable/immutable pattern. #97
+
 ## [0.5.1] - 2017-12-16
 
 ### Changed

--- a/derive_builder/Cargo.toml
+++ b/derive_builder/Cargo.toml
@@ -25,7 +25,7 @@ proc-macro = true
 [features]
 logging = [ "log", "env_logger", "derive_builder_core/logging" ]
 skeptic_tests = ["skeptic"]
-nightlytests = ["compiletest_rs", "getopts"]
+nightlytests = ["compiletest_rs"]
 
 [dependencies]
 syn = "0.11"
@@ -35,9 +35,6 @@ env_logger = { version = "0.4", optional = true }
 derive_builder_core = { version = "0.2", path = "../derive_builder_core" }
 skeptic = { version = "0.9", optional = true }
 compiletest_rs = { version = "0.3.3", optional = true }
-# `getopts 0.2.16` has a minimum requirement of Rust 1.18, so we pin it down to maintain a lower
-# minimum Rust version requirement.
-getopts = { version = "=0.2.15", optional = true }
 
 [build-dependencies]
 skeptic = { version = "0.9", optional = true }

--- a/derive_builder/Cargo.toml
+++ b/derive_builder/Cargo.toml
@@ -25,7 +25,7 @@ proc-macro = true
 [features]
 logging = [ "log", "env_logger", "derive_builder_core/logging" ]
 skeptic_tests = ["skeptic"]
-nightlytests = ["compiletest_rs"]
+nightlytests = ["compiletest_rs", "getopts"]
 
 [dependencies]
 syn = "0.11"
@@ -35,6 +35,9 @@ env_logger = { version = "0.4", optional = true }
 derive_builder_core = { version = "0.2", path = "../derive_builder_core" }
 skeptic = { version = "0.9", optional = true }
 compiletest_rs = { version = "0.3.3", optional = true }
+# `getopts 0.2.16` has a minimum requirement of Rust 1.18, so we pin it down to maintain a lower
+# minimum Rust version requirement.
+getopts = { version = "=0.2.15", optional = true }
 
 [build-dependencies]
 skeptic = { version = "0.9", optional = true }

--- a/derive_builder/src/lib.rs
+++ b/derive_builder/src/lib.rs
@@ -110,6 +110,8 @@
 //! ## Owned, aka Consuming
 //!
 //! Precede your struct (or field) with `#[builder(pattern = "owned")]` to opt into this pattern.
+//! Builders generated with this pattern do not automatically derive `Clone`, which allows builders
+//! to be generated for structs with fields that do not derive `Clone`.
 //!
 //! * Setters take and return `self`.
 //! * PRO: Setter calls and final build method can be chained.

--- a/derive_builder/src/lib.rs
+++ b/derive_builder/src/lib.rs
@@ -584,6 +584,9 @@ fn builder_for_struct(ast: syn::MacroInput) -> quote::Tokens {
     for f in fields {
         let f_opts = field_options_from(f, &field_defaults);
 
+        if f_opts.builder_pattern.requires_clone() {
+            builder.mark_initializer_requires_clone();
+        }
         builder.push_field(f_opts.as_builder_field());
         builder.push_setter_fn(f_opts.as_setter());
         build_fn.push_initializer(f_opts.as_initializer());

--- a/derive_builder/src/options/struct_options.rs
+++ b/derive_builder/src/options/struct_options.rs
@@ -47,6 +47,7 @@ impl StructOptions {
             visibility: &self.builder_visibility,
             fields: Vec::with_capacity(self.struct_size_hint),
             functions: Vec::with_capacity(self.struct_size_hint),
+            initializer_requires_clone: false,
             doc_comment: None,
             deprecation_notes: self.deprecation_notes.clone(),
             bindings: self.bindings,

--- a/dev/README.md
+++ b/dev/README.md
@@ -39,6 +39,15 @@ OK: All checks passed!
   e.g. `git push --no-verify`.
 * You can also run `dev/githook.sh` manually at any time, without
   registering it as a git hook. But you still have to do the configuration.
+* If the nightly tests fail with any of the following errors, your target directory may contain
+  stale artifacts:
+
+    ```
+    error[E0463]: can't find crate for `derive_builder`
+    error[E0464]: multiple matching crates for `derive_builder`
+    ```
+
+    Running `cargo clean` should remedy the issue.
 
 ## Configuration
 

--- a/dev/README.md
+++ b/dev/README.md
@@ -29,7 +29,7 @@ II: Running tests on stable... ✓
 II: Running tests on beta... ✓
 II: Running tests on nightly... ✓
 II: Running dev/compiletests.sh... ✓
-II: Running dev/checkfeatures.sh... ✓
+II: Running dev/checkminimumrust.sh... ✓
 OK: All checks passed!
 ```
 
@@ -53,5 +53,5 @@ git config hooks.checkstable true
 git config hooks.checkbeta true
 git config hooks.checknightly true
 git config hooks.compiletests true
-git config hooks.checkfeatures true
+git config hooks.checkminimumrust true
 ```

--- a/dev/checkminimumrust.sh
+++ b/dev/checkminimumrust.sh
@@ -1,10 +1,10 @@
 #!/bin/bash
 
 function main {
-  export CARGO_TARGET_DIR="../target/__checkfeatures"
+  export CARGO_TARGET_DIR="../target/__checkminimumrust"
 
   commands=(
-    "cd derive_builder && rustup run 1.15.0 cargo test --all --color always --features \"skeptic_tests\""
+    "cd derive_builder && rustup run 1.15.0 cargo test --all --color always"
   )
 
   dev/travis-run-all.sh "${commands[@]}"

--- a/dev/githook.sh
+++ b/dev/githook.sh
@@ -19,7 +19,7 @@
 #       git config hooks.checkbeta true
 #       git config hooks.checknightly true
 #       git config hooks.nightlytests true
-#       git config hooks.checkfeatures true
+#       git config hooks.checkminimumrust true
 #
 # Note this will stash all local changes.
 set -u
@@ -36,7 +36,7 @@ function main {
 	[ "$checkbeta" == true ] && run_tests_on "beta"
 	[ "$checknightly" == true ] && run_tests_on "nightly"
 	[ "$nightlytests" == true ] && run_script "dev/nightlytests.sh"
-	[ "$checkfeatures" == true ] && run_script "dev/checkfeatures.sh"
+	[ "$checkminimumrust" == true ] && run_script "dev/checkminimumrust.sh"
 
 	if [ "$errors" != 0 ]; then
 		echo -e "${FMT_ERR}EE${FMT_RESET}: Some checks failed!"
@@ -100,7 +100,7 @@ function load_config {
 	lookup_git_flag checkbeta
 	lookup_git_flag checknightly
 	lookup_git_flag nightlytests
-	lookup_git_flag checkfeatures
+	lookup_git_flag checkminimumrust
 
   if [ $config_status -ne 0 ]; then
 		echo -e "${FMT_ERR}EE${FMT_RESET}: Invalid git configuration. Aborting checks."

--- a/dev/githook.sh
+++ b/dev/githook.sh
@@ -101,6 +101,7 @@ function load_config {
 	lookup_git_flag checknightly
 	lookup_git_flag nightlytests
 	lookup_git_flag checkminimumrust
+	obsolete_git_flag checkfeatures '`hooks.checkfeatures` has been replaced by `hooks.checkminimumrust`'
 
   if [ $config_status -ne 0 ]; then
 		echo -e "${FMT_ERR}EE${FMT_RESET}: Invalid git configuration. Aborting checks."
@@ -140,6 +141,19 @@ function lookup_git_flag {
 		>&2 echo
 
 		config_status=1
+	fi
+}
+
+function obsolete_git_flag {
+	# lookup the boolean value of 'hooks.$1' (i.e. true or false)
+	# if it is set, then we inform the user that the flag is no longer in use
+	local flag="$(git config --bool hooks.$1)"
+	if [ "$flag" == true ] || [ "$flag" == false ]; then
+		[ -n "$2" ] && >&2 echo -e "${FMT_INFO}II${FMT_RESET}: $2"
+		>&2 echo -e "${FMT_INFO}II${FMT_RESET}: obsolete git flag found: hooks.$1"
+		>&2 echo "    you can remove it like"
+		>&2 echo "  $ git config --unset hooks.$1"
+		>&2 echo
 	fi
 }
 


### PR DESCRIPTION
Attempts to address #97, here's the quick summary:

* Made `Clone` optionally derived on the `Builder`, depending on the `BuilderPattern` on the struct as well as on each of the fields. I'm not sure if the way it calculates and passes the "mark this as should derive `Clone`" is a good way &mdash; it was the quickest way to get *most* of the tests to pass.
* Ran current Rustfmt over the repository.
* Updated top level docs (minor).
* Updated changelog.

The `./dev/checkfeatures.sh` run fails, but I couldn't figure out how to make it pass:

* `getopts 0.2.17` fails to compile:

    ```
    $ ./dev/checkfeatures.sh

    Running `cd derive_builder && rustup run 1.15.0 cargo test --all --color always --features "skeptic_tests"`
       Compiling getopts v0.2.17
    error[E0301]: cannot mutably borrow in a pattern guard
       --> /home/azriel/.cargo/registry/src/github.com-1ecc6299db9ec823/getopts-0.2.17/src/lib.rs:405:73
        |
    405 |                         } else if was_long || name_pos < names.len() || args.peek().map_or(true, |n| is_arg(&n)) {
        |                                                                         ^^^^ borrowed mutably in pattern guard

    error: aborting due to previous error

    error: Could not compile `getopts`.
    ```

* `Cargo.lock` says `compiletest_rs 0.3.7` depends on `getopts 0.2.17`.
* `Cargo.toml` in `derive_builder` says:

    ```toml
    [dependencies]
    # ... omitted
    compiletest_rs = { version = "0.3.3", optional = true }
    ```

Which, to me says "use version `0.3.3` of compiletest_rs" but cargo is disobeying that. Then I became sad because I tried munging dependencies, but cargo always chose `0.3.7` of `compiletest_rs`. I did delete `Cargo.lock` and try again + some other variations. Maybe this issue would solve that: https://github.com/rust-lang/cargo/issues/4100

<details>
<summary><i>Re-enactment of how I did this PR</I></summary>

* Ripgrep: `rg -F owned`.
* Hack code.
* `cargo test`
* `rg -F '::Owned'`.
* Fix compile errors.
* Read `CONTRIBUTING.md`
* Do what it says, ish 😀.
</details>