### PR TITLE
Update gitignore to exclude files generated by RLS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+/rls
 target
 Cargo.lock
 .*


### PR DESCRIPTION
Opened the project today and was blasted by untracked files created by RLS. Not sure if that's intentional or a bug on their side, but in the interest of unblocking development I've ignored it.