### PR TITLE
Only derive Clone on builders when necessary

### DIFF
--- a/derive_builder/CHANGELOG.md
+++ b/derive_builder/CHANGELOG.md
@@ -10,6 +10,10 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Updated to `quote` 0.5.2 #120
 - Removed support for deprecated attributes #120
 
+### Changes
+- `Clone` is no longer derived on a builder using the owned pattern unless it
+  has a field override that uses the mutable/immutable pattern. #97
+
 ### Internal Changes
 - Rewrote options parser using `darling` 0.6.3 #120
 

--- a/derive_builder/src/lib.rs
+++ b/derive_builder/src/lib.rs
@@ -110,6 +110,8 @@
 //! ## Owned, aka Consuming
 //!
 //! Precede your struct (or field) with `#[builder(pattern = "owned")]` to opt into this pattern.
+//! Builders generated with this pattern do not automatically derive `Clone`, which allows builders
+//! to be generated for structs with fields that do not derive `Clone`.
 //!
 //! * Setters take and return `self`.
 //! * PRO: Setter calls and final build method can be chained.

--- a/derive_builder/src/options/darling_opts.rs
+++ b/derive_builder/src/options/darling_opts.rs
@@ -319,14 +319,10 @@ impl Options {
             .fields
     }
 
-    /// A builder requires `Clone` to be derived if any of its fields use the mutable or immutable pattern.
-    ///
-    /// This can technically be expressed two ways:
-    ///
-    /// 1. The caller chooses the `owned` pattern at the struct level
-    /// 1. The caller chooses the `owned` pattern on every field
+    /// A builder requires `Clone` to be derived if its build method or any of its setters
+    /// use the mutable or immutable pattern.
     pub fn requires_clone(&self) -> bool {
-        self.fields().any(|f| f.pattern().requires_clone())
+        self.pattern.requires_clone() || self.fields().any(|f| f.pattern().requires_clone())
     }
 
     /// Get an iterator over the input struct's fields which pulls fallback

--- a/derive_builder/src/options/darling_opts.rs
+++ b/derive_builder/src/options/darling_opts.rs
@@ -294,6 +294,16 @@ impl Options {
             .fields
     }
 
+    /// A builder requires `Clone` to be derived if any of its fields use the mutable or immutable pattern.
+    ///
+    /// This can technically be expressed two ways:
+    ///
+    /// 1. The caller chooses the `owned` pattern at the struct level
+    /// 1. The caller chooses the `owned` pattern on every field
+    pub fn requires_clone(&self) -> bool {
+        self.fields().any(|f| f.pattern().requires_clone())
+    }
+
     /// Get an iterator over the input struct's fields which pulls fallback
     /// values from struct-level settings.
     pub fn fields<'a>(&'a self) -> FieldIter<'a> {
@@ -323,6 +333,7 @@ impl Options {
             visibility: self.builder_vis(),
             fields: Vec::with_capacity(self.field_count()),
             functions: Vec::with_capacity(self.field_count()),
+            must_derive_clone: self.requires_clone(),
             doc_comment: None,
             deprecation_notes: Default::default(),
             bindings: self.bindings(),


### PR DESCRIPTION
Builders using the owned pattern for all fields don't need Clone derived for them,
and therefore can be used with generics that don't support cloning.

Fixes #97, and obviates #111 

@azriel91, please review this.