### PR TITLE
Honor struct-level builder visibility attributes

### DIFF
--- a/derive_builder/CHANGELOG.md
+++ b/derive_builder/CHANGELOG.md
@@ -10,6 +10,9 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 - Updated to `quote` 0.5.2 #120
 - Removed support for deprecated attributes #120
 
+### Changes
+- Using `#[builder(private)]` at the struct level will now emit a private builder. #99
+
 ### Internal Changes
 - Rewrote options parser using `darling` 0.6.3 #120
 

--- a/derive_builder/src/options/darling_opts.rs
+++ b/derive_builder/src/options/darling_opts.rs
@@ -282,8 +282,11 @@ impl Options {
             .expect("Struct name with Builder suffix should be an ident")
     }
 
+    /// The visibility of the builder struct.
+    /// If a visibility was declared in attributes, that will be used;
+    /// otherwise the struct's own visibility will be used.
     pub fn builder_vis(&self) -> Visibility {
-        self.vis.clone()
+        self.as_expressed_vis().unwrap_or_else(|| self.vis.clone())
     }
 
     pub fn raw_fields<'a>(&'a self) -> Vec<&'a Field> {

--- a/derive_builder/tests/compile-fail/private_builder.rs
+++ b/derive_builder/tests/compile-fail/private_builder.rs
@@ -1,0 +1,25 @@
+#[macro_use]
+extern crate derive_builder;
+
+pub mod foo {
+    /// The builder struct's declaration of privacy should override the field's
+    /// attempt to be public later on.
+    #[derive(Debug, PartialEq, Default, Builder, Clone)]
+    #[builder(private, setter(into))]
+    pub struct Lorem {
+        pub private: String,
+        #[builder(public)]
+        pub public: String,
+    }
+}
+
+fn main() {
+    let x = foo::LoremBuilder::default()
+    //~^ ERROR struct `LoremBuilder` is private
+        .public("Hello")
+        .build()
+    //~^ ERROR method `build` is private
+        .unwrap();
+
+    assert_eq!(x.public, "Hello".to_string());
+}

--- a/derive_builder/tests/setter_visibility.rs
+++ b/derive_builder/tests/setter_visibility.rs
@@ -54,17 +54,6 @@ pub mod foo {
 
 #[test]
 #[should_panic(expected = "`private` must be initialized")]
-fn public_setters_override_foreign_module() {
-    let x = foo::LoremBuilder::default()
-        .public("Hello")
-        .build()
-        .unwrap();
-
-    assert_eq!(x.public, "Hello".to_string());
-}
-
-#[test]
-#[should_panic(expected = "`private` must be initialized")]
 fn public_setters_foreign_module() {
     let y = foo::IpsumBuilder::default()
         .public("Hello")
@@ -73,12 +62,3 @@ fn public_setters_foreign_module() {
 
     assert_eq!(y.public, "Hello".to_string());
 }
-
-// compile-test should fail with "error: method `ipsum` is private"
-// fn setters_foreign_module() {
-//     let x = foo::Lorem::default()
-//         .ipsum("Hello world!")
-//         .clone();
-//
-//     assert_eq!(x, foo::Lorem { ipsum: "Hello world!".into() });
-// }


### PR DESCRIPTION
Declaring a builder public or private now overrides the struct's own visibility.

Fixes #99