### PR TITLE
Handle generics in build method struct default instantiation

### DIFF
--- a/derive_builder/CHANGELOG.md
+++ b/derive_builder/CHANGELOG.md
@@ -2,6 +2,11 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.5.2] - Unreleased
+
+### Fixed
+- Generated code for structs with type parameters and struct-level defaults now compiles #127
+
 ## [0.5.1] - 2017-12-16
 
 ### Changed

--- a/derive_builder/tests/generic_with_default.rs
+++ b/derive_builder/tests/generic_with_default.rs
@@ -1,0 +1,38 @@
+#[macro_use]
+extern crate derive_builder;
+#[macro_use]
+extern crate pretty_assertions;
+
+/// Struct taken from `@shockham/caper` to make sure we emit the correct
+/// code for struct-level defaults in tandem with generics.
+#[derive(Builder, Clone, PartialEq)]
+#[builder(default)]
+pub struct RenderItem<T: Default> {
+    /// The vertices representing this items mesh
+    pub vertices: Vec<()>,
+    /// Whether the item is active/should be rendered
+    pub active: bool,
+    /// The name of the RenderItem for lookup
+    pub name: String,
+    /// Tag Type for grouping similar items
+    pub tag: T,
+}
+
+impl<T: Default> Default for RenderItem<T> {
+    fn default() -> Self {
+        RenderItem {
+            vertices: Default::default(),
+            active: true,
+            name: "ri".into(),
+            tag: Default::default(),
+        }
+    }
+}
+
+#[test]
+fn create_with_string() {
+    let ri: RenderItem<String> = RenderItemBuilder::default().build().unwrap();
+    assert_eq!(ri.tag, "");
+    assert_eq!(ri.name, "ri");
+    assert!(ri.active);
+}

--- a/derive_builder_core/src/build_method.rs
+++ b/derive_builder_core/src/build_method.rs
@@ -78,8 +78,8 @@ impl<'a> ToTokens for BuildMethod<'a> {
         };
         let doc_comment = &self.doc_comment;
         let default_struct = self.default_struct.as_ref().map(|default_expr| {
-            let ident = syn::Ident::new(DEFAULT_STRUCT_NAME);
-            quote!(let #ident: #target_ty = #default_expr;)
+            let ident = syn::Ident::from(DEFAULT_STRUCT_NAME);
+            quote!(let #ident: #target_ty #target_ty_generics = #default_expr;)
         });
         let validate_fn = self.validate_fn.as_ref().map(|vfn| quote!(#vfn(&self)?;));
         let result = self.bindings.result_ty();


### PR DESCRIPTION
Fixes #127 for 0.5.2 without requiring the full update to 0.6.0