### PR TITLE
Improve error experience

### DIFF
--- a/derive_builder/CHANGELOG.md
+++ b/derive_builder/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [0.7.1] - 2019-02-04
+- Updated `darling` to `0.8.5` and switched to better errors
+
 ## [0.7.0] - 2018-10-22
 
 ### Breaking Changes

--- a/derive_builder/Cargo.toml
+++ b/derive_builder/Cargo.toml
@@ -26,10 +26,9 @@ proc-macro = true
 logging = [ "log", "env_logger", "derive_builder_core/logging" ]
 skeptic_tests = ["skeptic"]
 nightlytests = ["compiletest_rs"]
-diagnostics = ["derive_builder_core/diagnostics", "darling/diagnostics"]
 
 [dependencies]
-darling = "0.8.4"
+darling = "0.8.5"
 proc-macro2 = "0.4"
 quote = "0.6"
 log = { version = "0.4", optional = true }

--- a/derive_builder/Cargo.toml
+++ b/derive_builder/Cargo.toml
@@ -26,16 +26,17 @@ proc-macro = true
 logging = [ "log", "env_logger", "derive_builder_core/logging" ]
 skeptic_tests = ["skeptic"]
 nightlytests = ["compiletest_rs"]
+diagnostics = ["derive_builder_core/diagnostics", "darling/diagnostics"]
 
 [dependencies]
-darling = "0.8"
+darling = "0.8.4"
 proc-macro2 = "0.4"
 quote = "0.6"
 log = { version = "0.4", optional = true }
 env_logger = { version = "0.5", optional = true }
 derive_builder_core = { version = "=0.4.0", path = "../derive_builder_core" }
 skeptic = { version = "0.13", optional = true }
-compiletest_rs = { version = "0.3.3", optional = true }
+compiletest_rs = { version = "0.3.18", optional = true }
 
 [dependencies.syn]
 version = "0.15"

--- a/derive_builder/src/lib.rs
+++ b/derive_builder/src/lib.rs
@@ -564,12 +564,7 @@ pub fn derive(input: TokenStream) -> TokenStream {
 
     let ast = parse_macro_input!(input as syn::DeriveInput);
 
-    let result = builder_for_struct(ast).to_string();
-    debug!("generated tokens: {}", result);
-
-    result
-        .parse()
-        .expect(&format!("Couldn't parse `{}` to tokens", result))
+    builder_for_struct(ast).into()
 }
 
 fn builder_for_struct(ast: syn::DeriveInput) -> proc_macro2::TokenStream {
@@ -577,13 +572,9 @@ fn builder_for_struct(ast: syn::DeriveInput) -> proc_macro2::TokenStream {
 
     let opts = match Options::from_derive_input(&ast) {
         Ok(val) => val,
-        #[cfg(feature = "diagnostics")]
         Err(err) => {
-            err.emit();
-            return quote!();
+            return err.write_errors();
         },
-        #[cfg(not(feature = "diagnostics"))]
-        Err(err) => panic!("{}", err.flatten()),
     };
 
     let mut builder = opts.as_builder();

--- a/derive_builder/src/options/mod.rs
+++ b/derive_builder/src/options/mod.rs
@@ -30,6 +30,9 @@ impl DefaultExpression {
     pub fn parse_block(&self, no_std: bool) -> Block {
         let expr = match *self {
             DefaultExpression::Explicit(ref s) => {
+                // We shouldn't hit this point in normal operation; the implementation
+                // of `FromMeta` returns an error in this case so that the error points
+                // at the empty expression rather than at the macro call-site.
                 if s.is_empty() {
                     panic!(r#"Empty default expressions `default = ""` are not supported."#);
                 }
@@ -53,6 +56,10 @@ impl darling::FromMeta for DefaultExpression {
     }
 
     fn from_string(value: &str) -> darling::Result<Self> {
-        Ok(DefaultExpression::Explicit(value.into()))
+        if value.is_empty() {
+            Err(darling::Error::unknown_value(""))
+        } else {
+            Ok(DefaultExpression::Explicit(value.into()))
+        }
     }
 }

--- a/derive_builder/tests/compile-fail/deny_empty_default.rs
+++ b/derive_builder/tests/compile-fail/deny_empty_default.rs
@@ -4,10 +4,9 @@ extern crate derive_builder;
 // deny `#[builder(default = "")]`, because we don't want to define a meaning (yet)! :-)
 #[allow(dead_code)]
 #[derive(Builder)]
-//~^ ERROR proc-macro derive panicked
-
 struct Lorem {
     #[builder(default = "")]
+    //~^ ERROR Unknown literal value ``
     ipsum: String,
 }
 

--- a/derive_builder/tests/compile-fail/rename_setter_struct_level.rs
+++ b/derive_builder/tests/compile-fail/rename_setter_struct_level.rs
@@ -4,8 +4,8 @@ extern crate pretty_assertions;
 extern crate derive_builder;
 
 #[derive(Debug, PartialEq, Default, Builder, Clone)]
-//~^ ERROR proc-macro derive panicked
 #[builder(setter(name = "foo"))]
+//~^ ERROR Unexpected field `name`
 struct Lorem {
     ipsum: &'static str,
     pub dolor: &'static str,

--- a/derive_builder/tests/ignore/no_std.rs
+++ b/derive_builder/tests/ignore/no_std.rs
@@ -1,8 +1,12 @@
+//! Compile behavior test for derive_builder on no_std. Unfortunately, this has broken
+//! too many times due to changes in requirements for no_std, and therefore this test
+//! is no longer part of the required nightly pass.
+
 // requires nightly toolchain!
 //
 // compile-flags:-C panic=abort
 #![no_std]
-#![feature(alloc, allocator_api, lang_items, start, core_intrinsics, oom, panic_implementation)]
+#![feature(alloc, allocator_api, lang_items, start, core_intrinsics, oom)]
 #![allow(dead_code)]
 use core::intrinsics;
 use core::panic::PanicInfo;
@@ -57,7 +61,7 @@ pub extern  fn eh_personality() {}
 pub extern fn rust_eh_unwind_resume() {
 }
 
-#[panic_implementation]
+#[panic_handler]
 #[no_mangle]
 fn panic(_info: &PanicInfo) -> ! {
     unsafe { intrinsics::abort() }

--- a/derive_builder_core/Cargo.toml
+++ b/derive_builder_core/Cargo.toml
@@ -15,13 +15,12 @@ readme = "README.md"
 
 [features]
 logging = [ "log" ]
-diagnostics = ["darling/diagnostics"]
 
 [badges]
 travis-ci = { repository = "colin-kiegel/rust-derive-builder" }
 
 [dependencies]
-darling = "0.8.4"
+darling = "0.8.5"
 proc-macro2 = "0.4"
 quote = "0.6"
 syn = { version = "0.15", features = ["full", "extra-traits"] }

--- a/derive_builder_core/Cargo.toml
+++ b/derive_builder_core/Cargo.toml
@@ -15,12 +15,13 @@ readme = "README.md"
 
 [features]
 logging = [ "log" ]
+diagnostics = ["darling/diagnostics"]
 
 [badges]
 travis-ci = { repository = "colin-kiegel/rust-derive-builder" }
 
 [dependencies]
-darling = "0.8"
+darling = "0.8.4"
 proc-macro2 = "0.4"
 quote = "0.6"
 syn = { version = "0.15", features = ["full", "extra-traits"] }


### PR DESCRIPTION
Using updates to the Rust compiler and to `darling`, make errors much nicer: They now point to the correct location in `#[builder(...)]` attributes, as seen in the compile-fail tests.