### PR TITLE
add strip_option to setter

### DIFF
--- a/derive_builder/CHANGELOG.md
+++ b/derive_builder/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+- Add `strip_option` flag for setter #116
+
 ## [0.7.1] - 2019-02-05
 - Updated `darling` to `0.8.5` and switched to better errors
 

--- a/derive_builder/README.md
+++ b/derive_builder/README.md
@@ -90,6 +90,7 @@ with [cargo-edit](https://github.com/killercup/cargo-edit):
 * **Hidden fields**: You can skip setters via `#[builder(setter(skip))]` on each field individually.
 * **Setter visibility**: You can opt into private setter by preceding your struct with `#[builder(private)]`.
 * **Setter type conversions**: With `#[builder(setter(into))]`, setter methods will be generic over the input types – you can then supply every argument that implements the [`Into`][into] trait for the field type.
+* **Setter strip option**: With `#[builder(setter(strip_option))]`, setter methods will take `T` as parameter'type for field of type `Option<T>`.
 * **Builder field visibility**: You can use `#[builder(field(private))]` or `..(public)`, to set field visibility of your builder.
 * **Generic structs**: Are also supported, but you **must not** use a type parameter named `VALUE`, if you also activate setter type conversions.
 * **Default values**: You can use `#[builder(default)]` to delegate to the `Default` implementation or any explicit value via ` = ".."`. This works both on the struct and field level.

--- a/derive_builder/src/lib.rs
+++ b/derive_builder/src/lib.rs
@@ -221,7 +221,38 @@
 //!     });
 //! }
 //! ```
+//! 
+//! ## Setters for Option
 //!
+//! You can avoid to user to wrap value into `Some(...)` for field of type `Option<T>`. It's as simple as adding
+//! `#[builder(setter(strip_option))]` to either a field or the whole struct.
+//!
+//! ```rust
+//! # #[macro_use]
+//! # extern crate derive_builder;
+//! #
+//! #[derive(Builder, Debug, PartialEq)]
+//! struct Lorem {
+//!     #[builder(setter(into, strip_option))]
+//!     pub ipsum: Option<String>,
+//!     #[builder(setter(into, strip_option), default)]
+//!     pub foo: Option<String>,
+//! }
+//!
+//! fn main() {
+//!     // `"foo"` will be converted into a `String` automatically.
+//!     let x = LoremBuilder::default().ipsum("foo").build().unwrap();
+//!
+//!     assert_eq!(x, Lorem {
+//!         ipsum: Some("foo".to_string()),
+//!         foo: None
+//!     });
+//! }
+//! ```
+//! If you want to set the value to None when unset, then enable `default` on this field (or do not use `strip_option`).
+//!
+//! Limitation: only the `Option` type name is supported, not type alias nor `std::option::Option`.
+//! 
 //! ## Fallible Setters
 //!
 //! Alongside the normal setter methods, you can expose fallible setters which are generic over

--- a/derive_builder/src/options/darling_opts.rs
+++ b/derive_builder/src/options/darling_opts.rs
@@ -93,6 +93,7 @@ impl FlagVisibility for FieldMeta {
 pub struct StructLevelSetter {
     prefix: Option<Ident>,
     into: Option<bool>,
+    strip_option: Option<bool>,
     skip: Option<bool>,
 }
 
@@ -113,6 +114,7 @@ pub struct FieldLevelSetter {
     prefix: Option<Ident>,
     name: Option<Ident>,
     into: Option<bool>,
+    strip_option: Option<bool>,
     skip: Option<bool>,
 }
 
@@ -125,7 +127,7 @@ impl FieldLevelSetter {
             return self.skip.map(|x| !x);
         }
 
-        if self.prefix.is_some() || self.name.is_some() || self.into.is_some() {
+        if self.prefix.is_some() || self.name.is_some() || self.into.is_some() || self.strip_option.is_some() {
             return Some(true);
         }
 
@@ -443,6 +445,16 @@ impl<'a> FieldWithDefaults<'a> {
             .unwrap_or_default()
     }
 
+    /// Checks if the emitted setter should strip the wrapper Option over types that impl
+    /// `Option<FieldType>`.
+    pub fn setter_strip_option(&self) -> bool {
+        self.field
+            .setter
+            .strip_option
+            .or(self.parent.setter.strip_option)
+            .unwrap_or_default()
+    }
+
     /// Get the visibility of the emitted setter, if there will be one.
     pub fn setter_vis(&self) -> Visibility {
         self.field
@@ -499,6 +511,7 @@ impl<'a> FieldWithDefaults<'a> {
             field_ident: &self.field_ident(),
             field_type: &self.field.ty,
             generic_into: self.setter_into(),
+            strip_option: self.setter_strip_option(),
             deprecation_notes: self.deprecation_notes(),
             bindings: self.bindings(),
         }

--- a/derive_builder/tests/setter_strip_option.rs
+++ b/derive_builder/tests/setter_strip_option.rs
@@ -24,25 +24,34 @@ struct Ipsum {
     strip_opt_with_default: Option<String>,
 }
 
-// #[test]
-// fn generic_field() {
-//     let x = LoremBuilder::default().full_opt(Some("foo".to_string())).strip_opt("bar").build().unwrap();
+#[test]
+fn generic_field() {
+    let x = LoremBuilder::default()
+        .full_opt(Some("foo".to_string()))
+        .strip_opt("bar")
+        .strip_opt_i32(32)
+        .strip_opt_vec(vec![33])
+        .build()
+        .unwrap();
 
-//     assert_eq!(
-//         x,
-//         Lorem {
-//             full_opt: Some("foo".to_string()),
-//             strip_opt: Some("bar".to_string()),
-//         }
-//     );
-// }
+    assert_eq!(
+        x,
+        Lorem {
+            full_opt: Some("foo".to_string()),
+            strip_opt: Some("bar".to_string()),
+            strip_opt_i32: Some(32),
+            strip_opt_vec: Some(vec![33]),
+        }
+    );
+}
 
-// #[test]
-// fn generic_struct() {
-//     let x = IpsumBuilder::default().foo(42u8).strip_opt("bar").build().unwrap();
+#[test]
+fn generic_struct() {
+    let x = IpsumBuilder::default().foo(42u8).strip_opt("bar").build().unwrap();
 
-//     assert_eq!(x, Ipsum {
-//         foo: 42u32,
-//         srip_opt: Some("bar".to_string()),
-//     });
-// }
+    assert_eq!(x, Ipsum {
+        foo: 42u32,
+        strip_opt: Some("bar".to_string()),
+        strip_opt_with_default: None,
+    });
+}

--- a/derive_builder/tests/setter_strip_option.rs
+++ b/derive_builder/tests/setter_strip_option.rs
@@ -1,0 +1,48 @@
+#[macro_use]
+extern crate pretty_assertions;
+#[macro_use]
+extern crate derive_builder;
+
+#[derive(Debug, PartialEq, Default, Builder, Clone)]
+struct Lorem {
+    #[builder(setter(into))]
+    full_opt: Option<String>,
+    #[builder(setter(into, strip_option))]
+    strip_opt: Option<String>,
+    #[builder(setter(strip_option))]
+    strip_opt_i32: Option<i32>,
+    #[builder(setter(strip_option))]
+    strip_opt_vec: Option<Vec<i32>>,
+}
+
+#[derive(Debug, PartialEq, Default, Builder, Clone)]
+#[builder(setter(into, strip_option))]
+struct Ipsum {
+    foo: u32,
+    strip_opt: Option<String>,
+    #[builder(default)]
+    strip_opt_with_default: Option<String>,
+}
+
+// #[test]
+// fn generic_field() {
+//     let x = LoremBuilder::default().full_opt(Some("foo".to_string())).strip_opt("bar").build().unwrap();
+
+//     assert_eq!(
+//         x,
+//         Lorem {
+//             full_opt: Some("foo".to_string()),
+//             strip_opt: Some("bar".to_string()),
+//         }
+//     );
+// }
+
+// #[test]
+// fn generic_struct() {
+//     let x = IpsumBuilder::default().foo(42u8).strip_opt("bar").build().unwrap();
+
+//     assert_eq!(x, Ipsum {
+//         foo: 42u32,
+//         srip_opt: Some("bar".to_string()),
+//     });
+// }

--- a/derive_builder_core/src/setter.rs
+++ b/derive_builder_core/src/setter.rs
@@ -178,8 +178,10 @@ fn extract_type_from_option(ty: &syn::Type) -> Option<&syn::Type> {
             && path.segments.iter().next().unwrap().ident == "Option"
     }
 
-    match ty {
-        syn::Type::Path(typepath) if typepath.qself.is_none() && path_is_option(&typepath.path) => {
+    match *ty {
+        syn::Type::Path(ref typepath)
+            if typepath.qself.is_none() && path_is_option(&typepath.path) =>
+        {
             // Get the first segment of the path (there is only one, in fact: "Option"):
             typepath
                 .path
@@ -188,13 +190,13 @@ fn extract_type_from_option(ty: &syn::Type) -> Option<&syn::Type> {
                 .and_then(|pair_path_segment| {
                     let type_params = &pair_path_segment.value().arguments;
                     // It should have only on angle-bracketed param ("<String>"):
-                    match type_params {
+                    match *type_params {
                         PathArguments::AngleBracketed(ref params) => params.args.first(),
                         _ => None,
                     }
                 })
-                .and_then(|generic_arg| match generic_arg.into_value() {
-                    GenericArgument::Type(ty) => Some(ty),
+                .and_then(|generic_arg| match *generic_arg.into_value() {
+                    GenericArgument::Type(ref ty) => Some(ty),
                     _ => None,
                 })
         }

--- a/derive_builder_core/src/setter.rs
+++ b/derive_builder_core/src/setter.rs
@@ -182,20 +182,21 @@ fn extract_type_from_option(ty: &syn::Type) -> Option<&syn::Type> {
     }
 
     // TODO store (with lazy static) precomputed parsing of Option when support of rust 1.18 will be removed (incompatible with lazy_static)
+    // TODO maybe optimization, reverse the order of segments
     fn extract_option_segment(path: &Path) -> Option<Pair<&PathSegment, &Colon2>> {
         let idents_of_path = path
             .segments
             .iter()
             .into_iter()
             .fold(String::new(), |mut acc, v| {
-                acc.push_str("::");
                 acc.push_str(&v.ident.to_string());
+                acc.push('|');
                 acc
             });
         vec![
-            "::Option",
-            "::std::option::Option",
-            "::core::option::Option",
+            "Option|",
+            "std|option|Option|",
+            "core|option|Option|",
         ]
         .into_iter()
         .find(|s| &idents_of_path == *s)


### PR DESCRIPTION
related to ticket #116 but with some difference against original request (mark with (!)):
- `strip_option` is a flag of setter
-  it can be applied at field or struct level
- (!) unset value is set to None, only if the field is builder is flagged with `default`
- (!) if the flag is applied on non Option<T>, then it is ignored (as it can be set on a struct with non Option field without generate error, less boiler plate to use IMHO, and match my target usage)

see change in lib.rs and test for usage.