### PR TITLE
Wait 10s before publishing `derive_builder`.

### DIFF
--- a/dev/deploy.sh
+++ b/dev/deploy.sh
@@ -9,6 +9,10 @@ function main {
   fi
 
   (cd derive_builder_core && rustup run nightly cargo publish --token "$CRATES_IO_TOKEN")
+
+  # Wait for `derive_builder_core` to be available on crates.io before publishing `derive_builder`
+  sleep 10
+
   (cd derive_builder      && rustup run nightly cargo publish --token "$CRATES_IO_TOKEN")
 }
 


### PR DESCRIPTION
Fixes #146.

Perhaps after fixing #149, it can be tested for real.