### PR TITLE
minor improvements

### DIFF
--- a/derive_builder/Cargo.toml
+++ b/derive_builder/Cargo.toml
@@ -47,4 +47,4 @@ log = { version = "0.4", optional = true }
 env_logger = { version = "0.5", optional = true }
 
 [dev-dependencies]
-pretty_assertions = "0.5"
+pretty_assertions = "0.6"

--- a/derive_builder/src/lib.rs
+++ b/derive_builder/src/lib.rs
@@ -221,7 +221,7 @@
 //!     });
 //! }
 //! ```
-//! 
+//!
 //! ## Setters for Option
 //!
 //! You can avoid to user to wrap value into `Some(...)` for field of type `Option<T>`. It's as simple as adding
@@ -252,7 +252,7 @@
 //! If you want to set the value to None when unset, then enable `default` on this field (or do not use `strip_option`).
 //!
 //! Limitation: only the `Option` type name is supported, not type alias nor `std::option::Option`.
-//! 
+//!
 //! ## Fallible Setters
 //!
 //! Alongside the normal setter methods, you can expose fallible setters which are generic over
@@ -605,7 +605,7 @@ fn builder_for_struct(ast: syn::DeriveInput) -> proc_macro2::TokenStream {
         Ok(val) => val,
         Err(err) => {
             return err.write_errors();
-        },
+        }
     };
 
     let mut builder = opts.as_builder();

--- a/derive_builder/src/options/darling_opts.rs
+++ b/derive_builder/src/options/darling_opts.rs
@@ -4,8 +4,8 @@ use derive_builder_core::BuildMethod;
 
 use darling::util::{Flag, PathList};
 use darling::{self, FromMeta};
-use syn::{self, Attribute, Generics, Ident, Path, Visibility};
 use proc_macro2::Span;
+use syn::{self, Attribute, Generics, Ident, Path, Visibility};
 
 use derive_builder_core::{
     Bindings, Builder, BuilderField, BuilderPattern, DeprecationNotes, Initializer, Setter,
@@ -127,7 +127,11 @@ impl FieldLevelSetter {
             return self.skip.map(|x| !x);
         }
 
-        if self.prefix.is_some() || self.name.is_some() || self.into.is_some() || self.strip_option.is_some() {
+        if self.prefix.is_some()
+            || self.name.is_some()
+            || self.into.is_some()
+            || self.strip_option.is_some()
+        {
             return Some(true);
         }
 
@@ -222,7 +226,11 @@ impl FlagVisibility for Field {
 }
 
 #[derive(Debug, Clone, FromDeriveInput)]
-#[darling(attributes(builder), forward_attrs(doc, cfg, allow), supports(struct_named))]
+#[darling(
+    attributes(builder),
+    forward_attrs(doc, cfg, allow),
+    supports(struct_named)
+)]
 pub struct Options {
     ident: Ident,
 

--- a/derive_builder/src/options/mod.rs
+++ b/derive_builder/src/options/mod.rs
@@ -38,11 +38,13 @@ impl DefaultExpression {
                 }
                 s
             }
-            DefaultExpression::Trait => if no_std {
-                "::core::default::Default::default()"
-            } else {
-                "::std::default::Default::default()"
-            },
+            DefaultExpression::Trait => {
+                if no_std {
+                    "::core::default::Default::default()"
+                } else {
+                    "::std::default::Default::default()"
+                }
+            }
         };
 
         expr.parse()

--- a/derive_builder/tests/custom_default.rs
+++ b/derive_builder/tests/custom_default.rs
@@ -13,15 +13,13 @@ mod field_level {
         escaped_default: String,
         #[builder(default = r#"format!("Hello {}!", "World")"#)]
         raw_default: String,
-        #[builder(
-            default = r#"format!("{}-{}-{}-{}",
+        #[builder(default = r#"format!("{}-{}-{}-{}",
                              Clone::clone(self.required
                                 .as_ref()
                                 .ok_or("required must be initialized")?),
                              match self.explicit_default { Some(ref x) => x, None => "EMPTY" },
                              self.escaped_default.as_ref().map(|x| x.as_ref()).unwrap_or("EMPTY"),
-                             if let Some(ref x) = self.raw_default { x } else { "EMPTY" })"#
-        )]
+                             if let Some(ref x) = self.raw_default { x } else { "EMPTY" })"#)]
         computed_default: String,
     }
 

--- a/derive_builder/tests/setter_strip_option.rs
+++ b/derive_builder/tests/setter_strip_option.rs
@@ -47,11 +47,18 @@ fn generic_field() {
 
 #[test]
 fn generic_struct() {
-    let x = IpsumBuilder::default().foo(42u8).strip_opt("bar").build().unwrap();
+    let x = IpsumBuilder::default()
+        .foo(42u8)
+        .strip_opt("bar")
+        .build()
+        .unwrap();
 
-    assert_eq!(x, Ipsum {
-        foo: 42u32,
-        strip_opt: Some("bar".to_string()),
-        strip_opt_with_default: None,
-    });
+    assert_eq!(
+        x,
+        Ipsum {
+            foo: 42u32,
+            strip_opt: Some("bar".to_string()),
+            strip_opt_with_default: None,
+        }
+    );
 }

--- a/derive_builder_core/Cargo.toml
+++ b/derive_builder_core/Cargo.toml
@@ -27,4 +27,4 @@ syn = { version = "1.0", features = ["full", "extra-traits"] }
 log = { version = "0.4", optional = true }
 
 [dev-dependencies]
-pretty_assertions = "0.5"
+pretty_assertions = "0.6"

--- a/derive_builder_core/src/bindings.rs
+++ b/derive_builder_core/src/bindings.rs
@@ -14,7 +14,8 @@ impl Bindings {
             "::alloc::string::String"
         } else {
             "::std::string::String"
-        }).unwrap()
+        })
+        .unwrap()
     }
 
     /// Result type.
@@ -23,7 +24,8 @@ impl Bindings {
             "::core::result::Result"
         } else {
             "::std::result::Result"
-        }).unwrap()
+        })
+        .unwrap()
     }
 
     /// Option type.
@@ -32,7 +34,8 @@ impl Bindings {
             "::core::option::Option"
         } else {
             "::std::option::Option"
-        }).unwrap()
+        })
+        .unwrap()
     }
 
     /// PhantomData type.
@@ -41,7 +44,8 @@ impl Bindings {
             "::core::marker::PhantomData"
         } else {
             "::std::marker::PhantomData"
-        }).unwrap()
+        })
+        .unwrap()
     }
 
     /// Default trait.
@@ -50,7 +54,8 @@ impl Bindings {
             "::core::default::Default"
         } else {
             "::std::default::Default"
-        }).unwrap()
+        })
+        .unwrap()
     }
 
     /// Clone trait.
@@ -59,7 +64,8 @@ impl Bindings {
             "::core::clone::Clone"
         } else {
             "::std::clone::Clone"
-        }).unwrap()
+        })
+        .unwrap()
     }
 
     /// Into trait.
@@ -69,7 +75,8 @@ impl Bindings {
             "::core::convert::Into"
         } else {
             "::std::convert::Into"
-        }).unwrap()
+        })
+        .unwrap()
     }
 
     /// TryInto trait.
@@ -78,6 +85,7 @@ impl Bindings {
             "::core::convert::TryInto"
         } else {
             "::std::convert::TryInto"
-        }).unwrap()
+        })
+        .unwrap()
     }
 }

--- a/derive_builder_core/src/bindings.rs
+++ b/derive_builder_core/src/bindings.rs
@@ -69,7 +69,7 @@ impl Bindings {
     }
 
     /// Into trait.
-    #[cfg_attr(feature = "cargo-clippy", allow(wrong_self_convention))]
+    #[allow(clippy::wrong_self_convention)]
     pub fn into_trait(&self) -> Path {
         syn::parse_str(if self.no_std {
             "::core::convert::Into"

--- a/derive_builder_core/src/block.rs
+++ b/derive_builder_core/src/block.rs
@@ -57,7 +57,7 @@ impl FromStr for Block {
     fn from_str(expr: &str) -> Result<Self, Self::Err> {
         let b: syn::Block =
             syn::parse_str(&format!("{{{}}}", expr)).map_err(|e| format!("{}", e))?;
-        Ok(Block(b.stmts))
+        Ok(Self(b.stmts))
     }
 }
 

--- a/derive_builder_core/src/block.rs
+++ b/derive_builder_core/src/block.rs
@@ -55,7 +55,8 @@ impl FromStr for Block {
     /// opening/closing delimiters like `{`, `(` and `[` will be _rejected_ as
     /// parsing error.
     fn from_str(expr: &str) -> Result<Self, Self::Err> {
-        let b: syn::Block = syn::parse_str(&format!("{{{}}}", expr)).map_err(|e| format!("{}", e))?;
+        let b: syn::Block =
+            syn::parse_str(&format!("{{{}}}", expr)).map_err(|e| format!("{}", e))?;
         Ok(Block(b.stmts))
     }
 }
@@ -66,9 +67,7 @@ mod test {
     use super::*;
 
     #[test]
-    #[should_panic(
-        expected = r#"LexError"#
-    )]
+    #[should_panic(expected = r#"LexError"#)]
     fn block_invalid_token_trees() {
         Block::from_str("let x = 2; { x+1").unwrap();
     }
@@ -83,7 +82,8 @@ mod test {
                 {
                     x + 1
                 }
-            }).to_string()
+            })
+            .to_string()
         );
     }
 

--- a/derive_builder_core/src/build_method.rs
+++ b/derive_builder_core/src/build_method.rs
@@ -1,6 +1,6 @@
 use doc_comment::doc_comment_from;
-use quote::{ToTokens, TokenStreamExt};
 use proc_macro2::{Span, TokenStream};
+use quote::{ToTokens, TokenStreamExt};
 use syn;
 use Bindings;
 use Block;
@@ -158,12 +158,13 @@ mod tests {
         assert_eq!(
             quote!(#build_method).to_string(),
             quote!(
-            pub fn build(&self) -> ::std::result::Result<Foo, ::std::string::String> {
-                Ok(Foo {
-                    foo: self.foo,
-                })
-            }
-        ).to_string()
+                pub fn build(&self) -> ::std::result::Result<Foo, ::std::string::String> {
+                    Ok(Foo {
+                        foo: self.foo,
+                    })
+                }
+            )
+            .to_string()
         );
     }
 
@@ -175,12 +176,13 @@ mod tests {
         assert_eq!(
             quote!(#build_method).to_string(),
             quote!(
-            pub fn build(&self) -> ::core::result::Result<Foo, ::alloc::string::String> {
-                Ok(Foo {
-                    foo: self.foo,
-                })
-            }
-        ).to_string()
+                pub fn build(&self) -> ::core::result::Result<Foo, ::alloc::string::String> {
+                    Ok(Foo {
+                        foo: self.foo,
+                    })
+                }
+            )
+            .to_string()
         );
     }
 
@@ -192,13 +194,14 @@ mod tests {
         assert_eq!(
             quote!(#build_method).to_string(),
             quote!(
-            pub fn build(&self) -> ::std::result::Result<Foo, ::std::string::String> {
-                let __default: Foo = {Default::default()};
-                Ok(Foo {
-                    foo: self.foo,
-                })
-            }
-        ).to_string()
+                pub fn build(&self) -> ::std::result::Result<Foo, ::std::string::String> {
+                    let __default: Foo = {Default::default()};
+                    Ok(Foo {
+                        foo: self.foo,
+                    })
+                }
+            )
+            .to_string()
         );
     }
 
@@ -220,12 +223,13 @@ mod tests {
         assert_eq!(
             quote!(#build_method).to_string(),
             quote!(
-            pub fn finish(&self) -> ::std::result::Result<Foo, ::std::string::String> {
-                Ok(Foo {
-                    foo: self.foo,
-                })
-            }
-        ).to_string()
+                pub fn finish(&self) -> ::std::result::Result<Foo, ::std::string::String> {
+                    Ok(Foo {
+                        foo: self.foo,
+                    })
+                }
+            )
+            .to_string()
         )
     }
 
@@ -240,14 +244,15 @@ mod tests {
         assert_eq!(
             quote!(#build_method).to_string(),
             quote!(
-            pub fn build(&self) -> ::std::result::Result<Foo, ::std::string::String> {
-                IpsumBuilder::validate(&self)?;
+                pub fn build(&self) -> ::std::result::Result<Foo, ::std::string::String> {
+                    IpsumBuilder::validate(&self)?;
 
-                Ok(Foo {
-                    foo: self.foo,
-                })
-            }
-        ).to_string()
+                    Ok(Foo {
+                        foo: self.foo,
+                    })
+                }
+            )
+            .to_string()
         );
     }
 }

--- a/derive_builder_core/src/builder.rs
+++ b/derive_builder_core/src/builder.rs
@@ -244,7 +244,7 @@ mod tests {
 
     // This test depends on the exact formatting of the `stringify`'d code,
     // so we don't automatically format the test
-    #[cfg_attr(rustfmt, rustfmt_skip)]
+    #[rustfmt::skip]
     #[test]
     fn generic() {
         let ast: syn::DeriveInput = syn::parse_str(stringify!(
@@ -274,7 +274,7 @@ mod tests {
 
     // This test depends on the exact formatting of the `stringify`'d code,
     // so we don't automatically format the test
-    #[cfg_attr(rustfmt, rustfmt_skip)]
+    #[rustfmt::skip]
     #[test]
     fn generic_reference() {
         let ast: syn::DeriveInput = syn::parse_str(stringify!(
@@ -305,7 +305,7 @@ mod tests {
 
     // This test depends on the exact formatting of the `stringify`'d code,
     // so we don't automatically format the test
-    #[cfg_attr(rustfmt, rustfmt_skip)]
+    #[rustfmt::skip]
     #[test]
     fn owned_generic() {
         let ast: syn::DeriveInput = syn::parse_str(stringify!(

--- a/derive_builder_core/src/builder.rs
+++ b/derive_builder_core/src/builder.rs
@@ -1,5 +1,5 @@
-use quote::{ToTokens, TokenStreamExt};
 use proc_macro2::TokenStream;
+use quote::{ToTokens, TokenStreamExt};
 use syn::punctuated::Punctuated;
 use syn::{self, Path, TraitBound, TraitBoundModifier, TypeParamBound};
 
@@ -226,18 +226,19 @@ mod tests {
         assert_eq!(
             quote!(#builder).to_string(),
             quote!(
-            #[derive(Default, Clone)]
-            pub struct FooBuilder {
-                foo: u32,
-            }
-
-            #[allow(dead_code)]
-            impl FooBuilder {
-                fn bar () -> {
-                    unimplemented!()
+                #[derive(Default, Clone)]
+                pub struct FooBuilder {
+                    foo: u32,
                 }
-            }
-        ).to_string()
+
+                #[allow(dead_code)]
+                impl FooBuilder {
+                    fn bar () -> {
+                        unimplemented!()
+                    }
+                }
+            )
+            .to_string()
         );
     }
 
@@ -344,25 +345,26 @@ mod tests {
 
     #[test]
     fn add_derives() {
-        let derives = vec![syn::parse_str("Serialize").unwrap(),];
+        let derives = vec![syn::parse_str("Serialize").unwrap()];
         let mut builder = default_builder!();
         builder.derives = &derives;
 
         assert_eq!(
             quote!(#builder).to_string(),
             quote!(
-            #[derive(Default, Clone, Serialize)]
-            pub struct FooBuilder {
-                foo: u32,
-            }
-
-            #[allow(dead_code)]
-            impl FooBuilder {
-                fn bar () -> {
-                    unimplemented!()
+                #[derive(Default, Clone, Serialize)]
+                pub struct FooBuilder {
+                    foo: u32,
                 }
-            }
-        ).to_string()
+
+                #[allow(dead_code)]
+                impl FooBuilder {
+                    fn bar () -> {
+                        unimplemented!()
+                    }
+                }
+            )
+            .to_string()
         );
     }
 }

--- a/derive_builder_core/src/builder_field.rs
+++ b/derive_builder_core/src/builder_field.rs
@@ -1,5 +1,5 @@
-use quote::{ToTokens, TokenStreamExt};
 use proc_macro2::TokenStream;
+use quote::{ToTokens, TokenStreamExt};
 use syn;
 use Bindings;
 
@@ -109,8 +109,9 @@ mod tests {
         assert_eq!(
             quote!(#field).to_string(),
             quote!(
-            #[some_attr] pub foo: ::std::option::Option<String>,
-        ).to_string()
+                #[some_attr] pub foo: ::std::option::Option<String>,
+            )
+            .to_string()
         );
     }
 
@@ -124,7 +125,8 @@ mod tests {
             quote!(
                 #[some_attr]
                 foo: ::std::marker::PhantomData<String>,
-            ).to_string()
+            )
+            .to_string()
         );
     }
 
@@ -136,8 +138,9 @@ mod tests {
         assert_eq!(
             quote!(#field).to_string(),
             quote!(
-            #[some_attr] pub foo: ::core::option::Option<String>,
-        ).to_string()
+                #[some_attr] pub foo: ::core::option::Option<String>,
+            )
+            .to_string()
         );
     }
 
@@ -152,7 +155,8 @@ mod tests {
             quote!(
                 #[some_attr]
                 foo: ::core::marker::PhantomData<String>,
-            ).to_string()
+            )
+            .to_string()
         );
     }
 
@@ -167,7 +171,8 @@ mod tests {
             quote!(
                 #[some_attr]
                 foo: ::std::option::Option<String>,
-            ).to_string()
+            )
+            .to_string()
         );
     }
 }

--- a/derive_builder_core/src/deprecation_notes.rs
+++ b/derive_builder_core/src/deprecation_notes.rs
@@ -1,5 +1,5 @@
-use quote::{ToTokens, TokenStreamExt};
 use proc_macro2::{Span, TokenStream};
+use quote::{ToTokens, TokenStreamExt};
 use syn;
 
 /// Deprecation notes we want to emit to the user, implementing
@@ -40,7 +40,8 @@ pub struct DeprecationNotes(Vec<String>);
 impl ToTokens for DeprecationNotes {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         for note in &self.0 {
-            let fn_ident = syn::Ident::new("derive_builder_core_deprecation_note", Span::call_site());
+            let fn_ident =
+                syn::Ident::new("derive_builder_core_deprecation_note", Span::call_site());
             tokens.append_all(quote!(
                 {
                     #[deprecated(note=#note)]
@@ -103,6 +104,7 @@ fn deprecation_note() {
             #[deprecated(note = "Some Warning")]
             fn derive_builder_core_deprecation_note() {}
             derive_builder_core_deprecation_note();
-        }).to_string()
+        })
+        .to_string()
     );
 }

--- a/derive_builder_core/src/deprecation_notes.rs
+++ b/derive_builder_core/src/deprecation_notes.rs
@@ -60,14 +60,14 @@ impl DeprecationNotes {
     }
 
     /// Extend this collection with all values from another collection.
-    pub fn extend(&mut self, other: &DeprecationNotes) {
+    pub fn extend(&mut self, other: &Self) {
         for x in &other.0 {
             self.0.push(x.to_owned())
         }
     }
 
     /// Create a view of these deprecation notes that can annotate a struct.
-    pub fn as_item(&self) -> DeprecationNotesAsItem {
+    pub const fn as_item(&self) -> DeprecationNotesAsItem {
         DeprecationNotesAsItem(self)
     }
 }

--- a/derive_builder_core/src/initializer.rs
+++ b/derive_builder_core/src/initializer.rs
@@ -1,5 +1,5 @@
-use quote::{ToTokens, TokenStreamExt};
 use proc_macro2::{Span, TokenStream};
+use quote::{ToTokens, TokenStreamExt};
 use syn;
 use Bindings;
 use Block;
@@ -218,13 +218,14 @@ mod tests {
         assert_eq!(
             quote!(#initializer).to_string(),
             quote!(
-            foo: match self.foo {
-                Some(ref value) => ::std::clone::Clone::clone(value),
-                None => return ::std::result::Result::Err(::std::string::String::from(
-                    "`foo` must be initialized"
-                )),
-            },
-        ).to_string()
+                foo: match self.foo {
+                    Some(ref value) => ::std::clone::Clone::clone(value),
+                    None => return ::std::result::Result::Err(::std::string::String::from(
+                        "`foo` must be initialized"
+                    )),
+                },
+            )
+            .to_string()
         );
     }
 
@@ -236,13 +237,14 @@ mod tests {
         assert_eq!(
             quote!(#initializer).to_string(),
             quote!(
-            foo: match self.foo {
-                Some(ref value) => ::std::clone::Clone::clone(value),
-                None => return ::std::result::Result::Err(::std::string::String::from(
-                    "`foo` must be initialized"
-                )),
-            },
-        ).to_string()
+                foo: match self.foo {
+                    Some(ref value) => ::std::clone::Clone::clone(value),
+                    None => return ::std::result::Result::Err(::std::string::String::from(
+                        "`foo` must be initialized"
+                    )),
+                },
+            )
+            .to_string()
         );
     }
 
@@ -254,13 +256,14 @@ mod tests {
         assert_eq!(
             quote!(#initializer).to_string(),
             quote!(
-            foo: match self.foo {
-                Some(value) => value,
-                None => return ::std::result::Result::Err(::std::string::String::from(
-                    "`foo` must be initialized"
-                )),
-            },
-        ).to_string()
+                foo: match self.foo {
+                    Some(value) => value,
+                    None => return ::std::result::Result::Err(::std::string::String::from(
+                        "`foo` must be initialized"
+                    )),
+                },
+            )
+            .to_string()
         );
     }
 
@@ -272,11 +275,12 @@ mod tests {
         assert_eq!(
             quote!(#initializer).to_string(),
             quote!(
-            foo: match self.foo {
-                Some(ref value) => ::std::clone::Clone::clone(value),
-                None => { 42 },
-            },
-        ).to_string()
+                foo: match self.foo {
+                    Some(ref value) => ::std::clone::Clone::clone(value),
+                    None => { 42 },
+                },
+            )
+            .to_string()
         );
     }
 
@@ -288,11 +292,12 @@ mod tests {
         assert_eq!(
             quote!(#initializer).to_string(),
             quote!(
-            foo: match self.foo {
-                Some(ref value) => ::std::clone::Clone::clone(value),
-                None => __default.foo,
-            },
-        ).to_string()
+                foo: match self.foo {
+                    Some(ref value) => ::std::clone::Clone::clone(value),
+                    None => __default.foo,
+                },
+            )
+            .to_string()
         );
     }
 
@@ -315,13 +320,14 @@ mod tests {
         assert_eq!(
             quote!(#initializer).to_string(),
             quote!(
-            foo: match self.foo {
-                Some(ref value) => ::core::clone::Clone::clone(value),
-                None => return ::core::result::Result::Err(::alloc::string::String::from(
-                    "`foo` must be initialized"
-                )),
-            },
-        ).to_string()
+                foo: match self.foo {
+                    Some(ref value) => ::core::clone::Clone::clone(value),
+                    None => return ::core::result::Result::Err(::alloc::string::String::from(
+                        "`foo` must be initialized"
+                    )),
+                },
+            )
+            .to_string()
         );
     }
 

--- a/derive_builder_core/src/initializer.rs
+++ b/derive_builder_core/src/initializer.rs
@@ -175,13 +175,13 @@ enum MatchSome {
 impl<'a> ToTokens for MatchSome {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         match *self {
-            MatchSome::Move => tokens.append_all(quote!(
+            Self::Move => tokens.append_all(quote!(
                 Some(value) => value
             )),
-            MatchSome::Clone => tokens.append_all(quote!(
+            Self::Clone => tokens.append_all(quote!(
                 Some(ref value) => ::std::clone::Clone::clone(value)
             )),
-            MatchSome::CloneNoStd => tokens.append_all(quote!(
+            Self::CloneNoStd => tokens.append_all(quote!(
                 Some(ref value) => ::core::clone::Clone::clone(value)
             )),
         }

--- a/derive_builder_core/src/lib.rs
+++ b/derive_builder_core/src/lib.rs
@@ -66,4 +66,4 @@ pub use initializer::Initializer;
 pub use options::BuilderPattern;
 pub use setter::Setter;
 
-const DEFAULT_STRUCT_NAME: &'static str = "__default";
+const DEFAULT_STRUCT_NAME: &str = "__default";

--- a/derive_builder_core/src/options.rs
+++ b/derive_builder_core/src/options.rs
@@ -23,13 +23,13 @@ impl BuilderPattern {
     /// Returns true if this style of builder needs to be able to clone its
     /// fields during the `build` method.
     pub fn requires_clone(&self) -> bool {
-        *self != BuilderPattern::Owned
+        *self != Self::Owned
     }
 }
 
 /// Defaults to `Mutable`.
 impl Default for BuilderPattern {
-    fn default() -> BuilderPattern {
-        BuilderPattern::Mutable
+    fn default() -> Self {
+        Self::Mutable
     }
 }

--- a/derive_builder_core/src/setter.rs
+++ b/derive_builder_core/src/setter.rs
@@ -193,14 +193,10 @@ fn extract_type_from_option(ty: &syn::Type) -> Option<&syn::Type> {
                 acc.push('|');
                 acc
             });
-        vec![
-            "Option|",
-            "std|option|Option|",
-            "core|option|Option|",
-        ]
-        .into_iter()
-        .find(|s| &idents_of_path == *s)
-        .and_then(|_| path.segments.last().map(Pair::End))
+        vec!["Option|", "std|option|Option|", "core|option|Option|"]
+            .into_iter()
+            .find(|s| &idents_of_path == *s)
+            .and_then(|_| path.segments.last().map(Pair::End))
     }
 
     extract_type_path(ty)

--- a/derive_builder_core/src/setter.rs
+++ b/derive_builder_core/src/setter.rs
@@ -1,4 +1,4 @@
-#![cfg_attr(feature = "cargo-clippy", allow(useless_let_if_seq))]
+#![allow(clippy::useless_let_if_seq)]
 use proc_macro2::{Span, TokenStream};
 use quote::{ToTokens, TokenStreamExt};
 use syn;
@@ -81,12 +81,15 @@ impl<'a> ToTokens for Setter<'a> {
             let clone = self.bindings.clone_trait();
             let option = self.bindings.option_ty();
             let into = self.bindings.into_trait();
-            let (ty, stripped_option) = match self.strip_option {
-                false => (field_type, false),
-                true => match extract_type_from_option(field_type) {
-                    None => (field_type, false),
-                    Some(ty) => (ty, true),
-                },
+            let (ty, stripped_option) = {
+                if self.strip_option {
+                    match extract_type_from_option(field_type) {
+                        Some(ty) => (ty, true),
+                        None => (field_type, false),
+                    }
+                } else {
+                    (field_type, false)
+                }
             };
 
             let self_param: TokenStream;
@@ -184,18 +187,14 @@ fn extract_type_from_option(ty: &syn::Type) -> Option<&syn::Type> {
     // TODO store (with lazy static) precomputed parsing of Option when support of rust 1.18 will be removed (incompatible with lazy_static)
     // TODO maybe optimization, reverse the order of segments
     fn extract_option_segment(path: &Path) -> Option<Pair<&PathSegment, &Colon2>> {
-        let idents_of_path = path
-            .segments
-            .iter()
-            .into_iter()
-            .fold(String::new(), |mut acc, v| {
-                acc.push_str(&v.ident.to_string());
-                acc.push('|');
-                acc
-            });
+        let idents_of_path = path.segments.iter().fold(String::new(), |mut acc, v| {
+            acc.push_str(&v.ident.to_string());
+            acc.push('|');
+            acc
+        });
         vec!["Option|", "std|option|Option|", "core|option|Option|"]
             .into_iter()
-            .find(|s| &idents_of_path == *s)
+            .find(|s| idents_of_path == *s)
             .and_then(|_| path.segments.last().map(Pair::End))
     }
 


### PR DESCRIPTION
I fixed most clippy lints, except the ones from below:
```
    Checking derive_builder_core v0.8.0 (/media/hdd/home/projects/rust-derive-builder/derive_builder_core)
error: this argument (1 byte) is passed by reference, but would be more efficient if passed by value (limit: 8 byte)
  --> derive_builder_core/src/bindings.rs:12:22
   |
12 |     pub fn string_ty(&self) -> Path {
   |                      ^^^^^ help: consider passing by value instead: `self`
   |
note: lint level defined here
  --> derive_builder_core/src/lib.rs:25:9
   |
25 | #![deny(warnings, missing_docs)]
   |         ^^^^^^^^
   = note: `#[deny(clippy::trivially_copy_pass_by_ref)]` implied by `#[deny(warnings)]`
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#trivially_copy_pass_by_ref

error: this argument (1 byte) is passed by reference, but would be more efficient if passed by value (limit: 8 byte)
 --> derive_builder_core/src/bindings.rs:22:22
  |
22|     pub fn result_ty(&self) -> Path {
  |                      ^^^^^ help: consider passing by value instead: `self`
  |
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#trivially_copy_pass_by_ref

error: this argument (1 byte) is passed by reference, but would be more efficient if passed by value (limit: 8 byte)
 --> derive_builder_core/src/bindings.rs:32:22
  |
32|     pub fn option_ty(&self) -> Path {
  |                      ^^^^^ help: consider passing by value instead: `self`
  |
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#trivially_copy_pass_by_ref

error: this argument (1 byte) is passed by reference, but would be more efficient if passed by value (limit: 8 byte)
 --> derive_builder_core/src/bindings.rs:42:28
  |
42|     pub fn phantom_data_ty(&self) -> Path {
  |                            ^^^^^ help: consider passing by value instead: `self`
  |
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#trivially_copy_pass_by_ref

error: this argument (1 byte) is passed by reference, but would be more efficient if passed by value (limit: 8 byte)
 --> derive_builder_core/src/bindings.rs:52:26
  |
52|     pub fn default_trait(&self) -> Path {
  |                          ^^^^^ help: consider passing by value instead: `self`
  |
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#trivially_copy_pass_by_ref

error: this argument (1 byte) is passed by reference, but would be more efficient if passed by value (limit: 8 byte)
 --> derive_builder_core/src/bindings.rs:62:24
  |
62|     pub fn clone_trait(&self) -> Path {
  |                        ^^^^^ help: consider passing by value instead: `self`
  |
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#trivially_copy_pass_by_ref

error: this argument (1 byte) is passed by reference, but would be more efficient if passed by value (limit: 8 byte)
 --> derive_builder_core/src/bindings.rs:73:23
  |
73|     pub fn into_trait(&self) -> Path {
  |                       ^^^^^ help: consider passing by value instead: `self`
  |
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#trivially_copy_pass_by_ref

error: this argument (1 byte) is passed by reference, but would be more efficient if passed by value (limit: 8 byte)
 --> derive_builder_core/src/bindings.rs:83:27
  |
83|     pub fn try_into_trait(&self) -> Path {
  |                           ^^^^^ help: consider passing by value instead: `self`
  |
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#trivially_copy_pass_by_ref

error: this argument (1 byte) is passed by reference, but would be more efficient if passed by value (limit: 8 byte)
 --> derive_builder_core/src/options.rs:25:27
  |
25|     pub fn requires_clone(&self) -> bool {
  |                           ^^^^^ help: consider passing by value instead: `self`
  |
  = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#trivially_copy_pass_by_ref

error: aborting due to 9 previous errors

error: could not compile `derive_builder_core`.

To learn more, run the command again with --verbose.
```