### PR TITLE
darling: bump for minimal version compatibility

### DIFF
--- a/derive_builder/Cargo.toml
+++ b/derive_builder/Cargo.toml
@@ -28,7 +28,7 @@ skeptic_tests = ["skeptic"]
 nightlytests = ["compiletest_rs"]
 
 [dependencies]
-darling = "0.10"
+darling = "0.10.2"
 proc-macro2 = "1.0"
 quote = "1.0"
 log = { version = "0.4", optional = true }

--- a/derive_builder_core/Cargo.toml
+++ b/derive_builder_core/Cargo.toml
@@ -20,7 +20,7 @@ logging = [ "log" ]
 travis-ci = { repository = "colin-kiegel/rust-derive-builder" }
 
 [dependencies]
-darling = "0.10"
+darling = "0.10.2"
 proc-macro2 = "1.0"
 quote = "1.0"
 syn = { version = "1.0", features = ["full", "extra-traits"] }


### PR DESCRIPTION
This allows `-Z minimal-versions` to be used in derive_builder-using
crates.

---
Needs a release of darling with TedDriggs/darling#83 included. Just making a guess at the version number it would use.