### PR TITLE
setter(custom) which allows a custom setter implementation

### DIFF
--- a/derive_builder/tests/setter_custom.rs
+++ b/derive_builder/tests/setter_custom.rs
@@ -1,0 +1,88 @@
+#[macro_use]
+extern crate pretty_assertions;
+#[macro_use]
+extern crate derive_builder;
+
+#[derive(Debug, PartialEq, Default, Builder, Clone)]
+#[builder(setter(skip = "false"), default)]
+struct SetterCustom {
+    #[builder(setter(custom = "true"))]
+    setter_custom_by_explicit_opt_in: u32,
+    #[builder(setter(custom))]
+    setter_custom_shorthand: u32,
+    #[builder(setter(custom = "false"))]
+    setter_custom_by_explicit_opt_out: u32,
+    #[builder(setter(custom = "true"), default="4")]
+    setter_custom_with_explicit_default: u32,
+    #[builder(setter(custom = "true", strip_option))]
+    setter_custom_with_strip_option: Option<u32>,
+}
+
+// compile test
+#[allow(dead_code)]
+impl SetterCustomBuilder {
+    // only possible if setter was skipped
+    fn setter_custom_by_explicit_opt_in(&mut self) -> &mut Self {
+        self.setter_custom_by_explicit_opt_in = Some(1);
+        self
+    }
+
+    // only possible if setter was skipped
+    fn setter_custom_shorthand(&mut self) -> &mut Self {
+        self.setter_custom_shorthand = Some(2);
+        self
+    }
+
+    // only possible if setter was skipped
+    fn setter_custom_with_explicit_default(&mut self) -> &mut Self {
+        self.setter_custom_with_explicit_default = Some(43);
+        self
+    }
+
+    // only possible if setter was skipped
+    fn setter_custom_with_strip_option(&mut self) -> &mut Self {
+        self.setter_custom_with_strip_option = Some(Some(6));
+        self
+    }
+}
+
+#[test]
+fn setter_custom_defaults() {
+    let x: SetterCustom = SetterCustomBuilder::default()
+        .build()
+        .unwrap();
+
+    assert_eq!(
+        x,
+        SetterCustom {
+            setter_custom_by_explicit_opt_in: 0,
+            setter_custom_shorthand: 0,
+            setter_custom_by_explicit_opt_out: 0,
+            setter_custom_with_explicit_default: 4,
+            setter_custom_with_strip_option: None,
+        }
+    );
+}
+
+#[test]
+fn setter_custom_setters_called() {
+    let x: SetterCustom = SetterCustomBuilder::default()
+        .setter_custom_by_explicit_opt_in() // set to 1
+        .setter_custom_shorthand() // set to 2
+        .setter_custom_by_explicit_opt_out(42)
+        .setter_custom_with_explicit_default() // set to 43
+        .setter_custom_with_strip_option() // set to 6
+        .build()
+        .unwrap();
+
+    assert_eq!(
+        x,
+        SetterCustom {
+            setter_custom_by_explicit_opt_in: 1,
+            setter_custom_shorthand: 2,
+            setter_custom_by_explicit_opt_out: 42,
+            setter_custom_with_explicit_default: 43,
+            setter_custom_with_strip_option: Some(6)
+        }
+    );
+}

--- a/derive_builder_core/src/builder_field.rs
+++ b/derive_builder_core/src/builder_field.rs
@@ -41,7 +41,7 @@ pub struct BuilderField<'a> {
     /// Note: We will fallback to `PhantomData` if the setter is disabled
     ///       to hack around issues with unused generic type parameters - at
     ///       least for now.
-    pub setter_enabled: bool,
+    pub field_enabled: bool,
     /// Visibility of this builder field, e.g. `syn::Visibility::Public`.
     pub field_visibility: syn::Visibility,
     /// Attributes which will be attached to this builder field.
@@ -52,7 +52,7 @@ pub struct BuilderField<'a> {
 
 impl<'a> ToTokens for BuilderField<'a> {
     fn to_tokens(&self, tokens: &mut TokenStream) {
-        if self.setter_enabled {
+        if self.field_enabled {
             trace!("Deriving builder field for `{}`.", self.field_ident);
             let vis = &self.field_visibility;
             let ident = self.field_ident;
@@ -89,7 +89,7 @@ macro_rules! default_builder_field {
         BuilderField {
             field_ident: &syn::Ident::new("foo", ::proc_macro2::Span::call_site()),
             field_type: &syn::parse_str("String").unwrap(),
-            setter_enabled: true,
+            field_enabled: true,
             field_visibility: syn::parse_str("pub").unwrap(),
             attrs: &[parse_quote!(#[some_attr])],
             bindings: Default::default(),
@@ -118,7 +118,7 @@ mod tests {
     #[test]
     fn setter_disabled() {
         let mut field = default_builder_field!();
-        field.setter_enabled = false;
+        field.field_enabled = false;
 
         assert_eq!(
             quote!(#field).to_string(),
@@ -148,7 +148,7 @@ mod tests {
     fn no_std_setter_disabled() {
         let mut field = default_builder_field!();
         field.bindings.no_std = true;
-        field.setter_enabled = false;
+        field.field_enabled = false;
 
         assert_eq!(
             quote!(#field).to_string(),

--- a/derive_builder_core/src/initializer.rs
+++ b/derive_builder_core/src/initializer.rs
@@ -40,7 +40,7 @@ pub struct Initializer<'a> {
     /// Name of the target field.
     pub field_ident: &'a syn::Ident,
     /// Whether the builder implements a setter for this field.
-    pub setter_enabled: bool,
+    pub field_enabled: bool,
     /// How the build method takes and returns `self` (e.g. mutably).
     pub builder_pattern: BuilderPattern,
     /// Default value for the target field.
@@ -59,7 +59,7 @@ impl<'a> ToTokens for Initializer<'a> {
 
         let struct_field = &self.field_ident;
 
-        if self.setter_enabled {
+        if self.field_enabled {
             let match_some = self.match_some();
             let match_none = self.match_none();
             let builder_field = &*struct_field;
@@ -196,7 +196,7 @@ macro_rules! default_initializer {
     () => {
         Initializer {
             field_ident: &syn::Ident::new("foo", ::proc_macro2::Span::call_site()),
-            setter_enabled: true,
+            field_enabled: true,
             builder_pattern: BuilderPattern::Mutable,
             default_value: None,
             use_default_struct: false,
@@ -304,7 +304,7 @@ mod tests {
     #[test]
     fn setter_disabled() {
         let mut initializer = default_initializer!();
-        initializer.setter_enabled = false;
+        initializer.field_enabled = false;
 
         assert_eq!(
             quote!(#initializer).to_string(),
@@ -335,7 +335,7 @@ mod tests {
     fn no_std_setter_disabled() {
         let mut initializer = default_initializer!();
         initializer.bindings.no_std = true;
-        initializer.setter_enabled = false;
+        initializer.field_enabled = false;
 
         assert_eq!(
             quote!(#initializer).to_string(),

--- a/derive_builder_core/src/setter.rs
+++ b/derive_builder_core/src/setter.rs
@@ -39,7 +39,7 @@ use DeprecationNotes;
 #[derive(Debug, Clone)]
 pub struct Setter<'a> {
     /// Enables code generation for this setter fn.
-    pub enabled: bool,
+    pub setter_enabled: bool,
     /// Enables code generation for the `try_` variant of this setter fn.
     pub try_setter: bool,
     /// Visibility of the setter, e.g. `syn::Visibility::Public`.
@@ -69,7 +69,7 @@ pub struct Setter<'a> {
 
 impl<'a> ToTokens for Setter<'a> {
     fn to_tokens(&self, tokens: &mut TokenStream) {
-        if self.enabled {
+        if self.setter_enabled {
             trace!("Deriving setter for `{}`.", self.field_ident);
             let field_type = self.field_type;
             let pattern = self.pattern;
@@ -221,7 +221,7 @@ fn extract_type_from_option(ty: &syn::Type) -> Option<&syn::Type> {
 macro_rules! default_setter {
     () => {
         Setter {
-            enabled: true,
+            setter_enabled: true,
             try_setter: false,
             visibility: syn::parse_str("pub").unwrap(),
             pattern: BuilderPattern::Mutable,
@@ -461,7 +461,7 @@ mod tests {
     #[test]
     fn setter_disabled() {
         let mut setter = default_setter!();
-        setter.enabled = false;
+        setter.setter_enabled = false;
 
         assert_eq!(quote!(#setter).to_string(), quote!().to_string());
     }


### PR DESCRIPTION
Implements feature request #110

First I added an option to the `FieldLevelSetter` called `custom`. Such that the attribute is `#[builder(setter(custom))]`.

This option will behave like `skip` but not cause the field to be "skipped" (i.e. replaced with `PhantomData`). This is done by splitting the `enabled` flag into `setter_enabled` and `field_enabled`. `custom` will only cause the setter to be disabled, but not the field.

I'm aware that `custom` is missing for `StructLevelSetter`. To be honest, it's late and I need the feature. I can implement it tomorrow, if necessary :)

Tests are implemented in `tests/setter_custom.rs`.

I just started using this crate today and didn't look to deep into the code and it's capabilities (doc seems to be lacking). So there might be some inter-dependencies I overlooked. I copied the tests from `skip-setters.rs` and adapted them. I also added a test for `strip_option` as this might be a common usecase together with `custom`.

If there are any recommendations for improvements, let me know. 