### PR TITLE
Remove nightlytests feature flag. Run all tests on all versions of Rust.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ rust:
   - beta
   - stable
   - nightly
-  - 1.37.0
+  - 1.40.0
 matrix:
   include:
     - rust: stable

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,19 +8,18 @@ rust:
   - 1.37.0
 matrix:
   include:
-    - rust: nightly
-      env: JOB=test CARGO_FEATURES="skeptic_tests nightlytests logging"
     - rust: stable
       env: JOB=style_check
   allow_failures:
     - env: JOB=style_check
-    - env: JOB=test CARGO_FEATURES="skeptic_tests nightlytests logging"
   fast_finish: true
 env:
   matrix:
-    - JOB=test
+  - JOB=test CARGO_FEATURES=""
+  - JOB=test CARGO_FEATURES="skeptic_tests"
+  - JOB=test CARGO_FEATURES="logging"
+  - JOB=test CARGO_FEATURES="skeptic_tests logging"
   global:
-  - CARGO_FEATURES=""
   - RUST_BACKTRACE=1
   - TRAVIS_CARGO_NIGHTLY_FEATURE=""
   - PKGNAME=derive_builder

--- a/derive_builder/CHANGELOG.md
+++ b/derive_builder/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+- Requires Rust 1.40.0 or newer (was 1.37.0) #169
+
 ## [0.9.0] - 2019-11-07
 - Add `setter(custom)` to allow implementing a custom setter #154
 

--- a/derive_builder/Cargo.toml
+++ b/derive_builder/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "derive_builder"
-version = "0.9.0"
+version = "0.10.0-alpha"
 authors = ["Colin Kiegel <kiegel@gmx.de>",
            "Pascal Hertleif <killercup@gmail.com>",
            "Jan-Erik Rediger <janerik@fnordig.de>",
@@ -8,7 +8,7 @@ authors = ["Colin Kiegel <kiegel@gmx.de>",
 
 description = "Rust macro to automatically implement the builder pattern for arbitrary structs."
 repository = "https://github.com/colin-kiegel/rust-derive-builder"
-documentation = "https://docs.rs/derive_builder/0.9.0"
+documentation = "https://docs.rs/derive_builder/0.10.0-alpha"
 
 license = "MIT/Apache-2.0"
 categories = ["development-tools", "rust-patterns"]
@@ -33,7 +33,7 @@ proc-macro2 = "1.0"
 quote = "1.0"
 log = { version = "0.4", optional = true }
 env_logger = { version = "0.5", optional = true }
-derive_builder_core = { version = "=0.9.0", path = "../derive_builder_core" }
+derive_builder_core = { version = "=0.10.0-alpha", path = "../derive_builder_core" }
 skeptic = { version = "0.13", optional = true }
 
 [dependencies.syn]

--- a/derive_builder/Cargo.toml
+++ b/derive_builder/Cargo.toml
@@ -25,7 +25,6 @@ proc-macro = true
 [features]
 logging = [ "log", "env_logger", "derive_builder_core/logging" ]
 skeptic_tests = ["skeptic"]
-nightlytests = ["compiletest_rs"]
 clippy = ["derive_builder_core/clippy"]
 
 [dependencies]
@@ -36,7 +35,6 @@ log = { version = "0.4", optional = true }
 env_logger = { version = "0.5", optional = true }
 derive_builder_core = { version = "=0.9.0", path = "../derive_builder_core" }
 skeptic = { version = "0.13", optional = true }
-compiletest_rs = { version = "0.3.18", optional = true }
 
 [dependencies.syn]
 version = "1.0"
@@ -49,3 +47,4 @@ env_logger = { version = "0.5", optional = true }
 
 [dev-dependencies]
 pretty_assertions = "0.6"
+compiletest_rs = "0.5"

--- a/derive_builder/README.md
+++ b/derive_builder/README.md
@@ -1,5 +1,5 @@
 [![Build status](https://travis-ci.org/colin-kiegel/rust-derive-builder.svg?branch=master)](https://travis-ci.org/colin-kiegel/rust-derive-builder)
-[![Rust version]( https://img.shields.io/badge/rust-1.37+-blue.svg)]()
+[![Rust version]( https://img.shields.io/badge/rust-1.40+-blue.svg)]()
 [![Documentation](https://docs.rs/derive_builder/badge.svg)](https://docs.rs/derive_builder)
 [![Latest version](https://img.shields.io/crates/v/derive_builder.svg)](https://crates.io/crates/derive_builder)
 [![All downloads](https://img.shields.io/crates/d/derive_builder.svg)](https://crates.io/crates/derive_builder)

--- a/derive_builder/build/skeptic.rs
+++ b/derive_builder/build/skeptic.rs
@@ -14,7 +14,7 @@ mod log_disabled {
 fn main() {
     println!("INFO: Run with `RUST_LOG=build_script_build=trace` for debug information.");
     #[cfg(feature = "logging")]
-    env_logger::init().unwrap();
+    env_logger::init();
 
     let mut files = generate_doc_tpl_tests().unwrap();
     files.push("README.md".to_string());

--- a/derive_builder/src/lib.rs
+++ b/derive_builder/src/lib.rs
@@ -265,13 +265,8 @@
 //! to add `#![feature(try_from)]` to your crate to use it.
 //!
 //! ```rust
-//! // #![feature(try_from)]
-//! # #![cfg_attr(feature = "nightlytests", feature(try_from))]
-//! # #[cfg(feature = "nightlytests")]
 //! # #[macro_use]
 //! # extern crate derive_builder;
-//! #
-//! # #[cfg(feature = "nightlytests")]
 //! #[derive(Builder, Debug, PartialEq)]
 //! #[builder(try_setter, setter(into))]
 //! struct Lorem {
@@ -279,7 +274,6 @@
 //!     pub ipsum: u8,
 //! }
 //!
-//! # #[cfg(feature = "nightlytests")]
 //! #[derive(Builder, Debug, PartialEq)]
 //! struct Ipsum {
 //!     #[builder(try_setter, setter(into, name = "foo"))]
@@ -287,14 +281,12 @@
 //! }
 //!
 //! fn main() {
-//! #  #[cfg(feature = "nightlytests")]
 //!    LoremBuilder::default()
 //!        .try_ipsum(1u16).unwrap()
 //!        .name("hello")
 //!        .build()
 //!        .expect("1 fits into a u8");
 //!
-//! #  #[cfg(feature = "nightlytests")]
 //!    IpsumBuilder::default()
 //!        .try_foo(1u16).unwrap()
 //!        .build()
@@ -580,17 +572,17 @@ use darling::FromDeriveInput;
 use options::Options;
 use proc_macro::TokenStream;
 #[cfg(feature = "logging")]
-use std::sync::{Once, ONCE_INIT};
+use std::sync::Once;
 
 #[cfg(feature = "logging")]
-static INIT_LOGGER: Once = ONCE_INIT;
+static INIT_LOGGER: Once = Once::new();
 
 #[doc(hidden)]
 #[proc_macro_derive(Builder, attributes(builder))]
 pub fn derive(input: TokenStream) -> TokenStream {
     #[cfg(feature = "logging")]
     INIT_LOGGER.call_once(|| {
-        env_logger::init().unwrap();
+        env_logger::init();
     });
 
     let ast = parse_macro_input!(input as syn::DeriveInput);

--- a/derive_builder/tests/compile-fail/private_build_fn.rs
+++ b/derive_builder/tests/compile-fail/private_build_fn.rs
@@ -25,7 +25,7 @@ fn main() {
     let lorem1 = LoremBuilder::default().my_build();
 
     let lorem2 = LoremBuilder::default().build().unwrap();
-    //~^ ERROR associated function `build` is private
+    //~^ ERROR `build` is private
 
     println!("{:?} vs {:?}", lorem1, lorem2);
 }

--- a/derive_builder/tests/compile-fail/private_build_fn.rs
+++ b/derive_builder/tests/compile-fail/private_build_fn.rs
@@ -25,7 +25,7 @@ fn main() {
     let lorem1 = LoremBuilder::default().my_build();
 
     let lorem2 = LoremBuilder::default().build().unwrap();
-    //~^ ERROR method `build` is private
+    //~^ ERROR associated function `build` is private
 
     println!("{:?} vs {:?}", lorem1, lorem2);
 }

--- a/derive_builder/tests/compile-fail/private_builder.rs
+++ b/derive_builder/tests/compile-fail/private_builder.rs
@@ -18,7 +18,7 @@ fn main() {
     //~^ ERROR struct `LoremBuilder` is private
         .public("Hello")
         .build()
-    //~^ ERROR associated function `build` is private
+    //~^ ERROR `build` is private
         .unwrap();
 
     assert_eq!(x.public, "Hello".to_string());

--- a/derive_builder/tests/compile-fail/private_builder.rs
+++ b/derive_builder/tests/compile-fail/private_builder.rs
@@ -18,7 +18,7 @@ fn main() {
     //~^ ERROR struct `LoremBuilder` is private
         .public("Hello")
         .build()
-    //~^ ERROR method `build` is private
+    //~^ ERROR associated function `build` is private
         .unwrap();
 
     assert_eq!(x.public, "Hello".to_string());

--- a/derive_builder/tests/compile-fail/rename_setter_struct_level.rs
+++ b/derive_builder/tests/compile-fail/rename_setter_struct_level.rs
@@ -5,15 +5,15 @@ extern crate derive_builder;
 
 #[derive(Debug, PartialEq, Default, Builder, Clone)]
 #[builder(setter(name = "foo"))]
-//~^ ERROR Unexpected field `name`
+//~^ ERROR Unknown field: `name`
 struct Lorem {
     ipsum: &'static str,
     pub dolor: &'static str,
 }
 
-#[test]
-fn renamed_setter() {
+fn main() {
     let x = LoremBuilder::default()
+    //~^ ERROR use of undeclared type or module `LoremBuilder`
         .ipsum("ipsum")
         .foo("dolor")
         .build()

--- a/derive_builder/tests/compiletests.rs
+++ b/derive_builder/tests/compiletests.rs
@@ -1,10 +1,4 @@
-#![cfg(feature = "nightlytests")]
 extern crate compiletest_rs as compiletest;
-
-// note:
-// - `env::var("PROFILE")` is only available vor build scripts
-//   http://doc.crates.io/environment-variables.html
-const PROFILE: &'static str = "debug";
 
 use std::env;
 use std::path::PathBuf;
@@ -23,17 +17,8 @@ fn run_mode(mode: &'static str) {
 
     config.mode = cfg_mode;
     config.src_base = test_dir;
-
-    // note:
-    // - cargo respects the environment variable `env::var("CARGO_TARGET_DIR")`,
-    //   however if this is not set and a virtual manifest is used, we will *not*
-    //   know the path :-(
-    // In that case try to set `CARGO_TARGET_DIR` manually, e.g.
-    // `/path/to/my_workspace/target`.
-    let build_dir = env::var("CARGO_TARGET_DIR").unwrap_or(format!("{}/target", base_dir));
-    let artefacts_dir = format!("{}/{}", build_dir, PROFILE);
-
-    config.target_rustcflags = Some(format!("-L {} -L {}/deps", artefacts_dir, artefacts_dir));
+    config.link_deps();
+    config.clean_rmeta();
 
     compiletest::run_tests(&config);
 }

--- a/derive_builder/tests/try_setter.rs
+++ b/derive_builder/tests/try_setter.rs
@@ -1,6 +1,3 @@
-#![cfg(feature = "nightlytests")]
-#![feature(try_from)]
-
 #[macro_use]
 extern crate derive_builder;
 
@@ -18,7 +15,6 @@ impl From<IpAddr> for MyAddr {
     }
 }
 
-#[cfg(feature = "nightlytests")]
 impl<'a> TryFrom<&'a str> for MyAddr {
     type Error = AddrParseError;
 
@@ -47,7 +43,6 @@ fn exact_helper() -> Result<Lorem, String> {
         .build()
 }
 
-#[cfg(feature = "nightlytests")]
 fn try_helper() -> Result<Lorem, String> {
     LoremBuilder::default()
         .try_source("1.2.3.4")
@@ -66,7 +61,6 @@ fn infallible_set() {
 }
 
 #[test]
-#[cfg(feature = "nightlytests")]
 fn fallible_set() {
     let mut builder = LoremBuilder::default();
     let try_result = builder.try_source("1.2.3.4");
@@ -79,13 +73,11 @@ fn fallible_set() {
 }
 
 #[test]
-#[cfg(feature = "nightlytests")]
 fn with_helper() {
     assert_eq!(exact_helper().unwrap(), try_helper().unwrap());
 }
 
 #[test]
-#[cfg(feature = "nightlytests")]
 fn renamed() {
     IpsumBuilder::default()
         .try_set_source("0.0.0.0")

--- a/derive_builder_core/Cargo.toml
+++ b/derive_builder_core/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "derive_builder_core"
-version = "0.9.0"
+version = "0.10.0-alpha"
 authors = ["Colin Kiegel <kiegel@gmx.de>",
            "Pascal Hertleif <killercup@gmail.com>",
            "Jan-Erik Rediger <janerik@fnordig.de>",


### PR DESCRIPTION
This PR also bumps minimal version from 1.37.0 to 1.40.0. Skeptic and compiler tests require at least 1.38.0 and `#[non_exhaustive]` feature in PR #169 needs at least 1.40.0.

This also closes #140 