### PR TITLE
Migrate from compiletest_rs to trybuild

### DIFF
--- a/derive_builder/Cargo.toml
+++ b/derive_builder/Cargo.toml
@@ -32,8 +32,9 @@ derive_builder_core = { version = "=0.10.0-alpha", path = "../derive_builder_cor
 
 [dev-dependencies]
 pretty_assertions = "0.6"
-compiletest_rs = "0.5"
 skeptic = "0.13"
+rustversion = "1"
+trybuild = "1"
 
 [build-dependencies]
 skeptic = { version = "0.13", optional = true }

--- a/derive_builder/tests/compile-fail/deny_empty_default.rs
+++ b/derive_builder/tests/compile-fail/deny_empty_default.rs
@@ -6,7 +6,6 @@ extern crate derive_builder;
 #[derive(Builder)]
 struct Lorem {
     #[builder(default = "")]
-    //~^ ERROR Unknown literal value ``
     ipsum: String,
 }
 

--- a/derive_builder/tests/compile-fail/deny_empty_default.stderr
+++ b/derive_builder/tests/compile-fail/deny_empty_default.stderr
@@ -1,0 +1,5 @@
+error: Unknown literal value ``
+ --> $DIR/deny_empty_default.rs:8:25
+  |
+8 |     #[builder(default = "")]
+  |                         ^^

--- a/derive_builder/tests/compile-fail/private_build_fn.rs
+++ b/derive_builder/tests/compile-fail/private_build_fn.rs
@@ -25,7 +25,6 @@ fn main() {
     let lorem1 = LoremBuilder::default().my_build();
 
     let lorem2 = LoremBuilder::default().build().unwrap();
-    //~^ ERROR `build` is private
 
     println!("{:?} vs {:?}", lorem1, lorem2);
 }

--- a/derive_builder/tests/compile-fail/private_build_fn.stderr
+++ b/derive_builder/tests/compile-fail/private_build_fn.stderr
@@ -1,0 +1,13 @@
+warning: unused import: `Lorem`
+  --> $DIR/private_build_fn.rs:23:21
+   |
+23 |     use container::{Lorem, LoremBuilder};
+   |                     ^^^^^
+   |
+   = note: `#[warn(unused_imports)]` on by default
+
+error[E0624]: method `build` is private
+  --> $DIR/private_build_fn.rs:27:42
+   |
+27 |     let lorem2 = LoremBuilder::default().build().unwrap();
+   |                                          ^^^^^

--- a/derive_builder/tests/compile-fail/private_builder.rs
+++ b/derive_builder/tests/compile-fail/private_builder.rs
@@ -15,10 +15,8 @@ pub mod foo {
 
 fn main() {
     let x = foo::LoremBuilder::default()
-    //~^ ERROR struct `LoremBuilder` is private
         .public("Hello")
         .build()
-    //~^ ERROR `build` is private
         .unwrap();
 
     assert_eq!(x.public, "Hello".to_string());

--- a/derive_builder/tests/compile-fail/private_builder.stderr
+++ b/derive_builder/tests/compile-fail/private_builder.stderr
@@ -1,0 +1,11 @@
+error[E0603]: struct `LoremBuilder` is private
+  --> $DIR/private_builder.rs:17:18
+   |
+17 |     let x = foo::LoremBuilder::default()
+   |                  ^^^^^^^^^^^^
+
+error[E0624]: method `build` is private
+  --> $DIR/private_builder.rs:19:10
+   |
+19 |         .build()
+   |          ^^^^^

--- a/derive_builder/tests/compile-fail/private_fields.rs
+++ b/derive_builder/tests/compile-fail/private_fields.rs
@@ -23,5 +23,4 @@ fn main() {
     lorem.dolor(15u16);
     lorem.sit = Some(true); // <-- public
     lorem.dolor = Some(0); // <-- private
-    //~^ ERROR field `dolor` of struct `inner::LoremBuilder` is private
 }

--- a/derive_builder/tests/compile-fail/private_fields.stderr
+++ b/derive_builder/tests/compile-fail/private_fields.stderr
@@ -1,0 +1,5 @@
+error[E0616]: field `dolor` of struct `inner::LoremBuilder` is private
+  --> $DIR/private_fields.rs:25:5
+   |
+25 |     lorem.dolor = Some(0); // <-- private
+   |     ^^^^^^^^^^^

--- a/derive_builder/tests/compile-fail/rename_setter_struct_level.rs
+++ b/derive_builder/tests/compile-fail/rename_setter_struct_level.rs
@@ -5,7 +5,6 @@ extern crate derive_builder;
 
 #[derive(Debug, PartialEq, Default, Builder, Clone)]
 #[builder(setter(name = "foo"))]
-//~^ ERROR Unknown field: `name`
 struct Lorem {
     ipsum: &'static str,
     pub dolor: &'static str,
@@ -13,7 +12,6 @@ struct Lorem {
 
 fn main() {
     let x = LoremBuilder::default()
-    //~^ ERROR use of undeclared type or module `LoremBuilder`
         .ipsum("ipsum")
         .foo("dolor")
         .build()

--- a/derive_builder/tests/compile-fail/rename_setter_struct_level.stderr
+++ b/derive_builder/tests/compile-fail/rename_setter_struct_level.stderr
@@ -1,0 +1,11 @@
+error: Unknown field: `name`
+ --> $DIR/rename_setter_struct_level.rs:7:18
+  |
+7 | #[builder(setter(name = "foo"))]
+  |                  ^^^^
+
+error[E0433]: failed to resolve: use of undeclared type or module `LoremBuilder`
+  --> $DIR/rename_setter_struct_level.rs:14:13
+   |
+14 |     let x = LoremBuilder::default()
+   |             ^^^^^^^^^^^^ use of undeclared type or module `LoremBuilder`

--- a/derive_builder/tests/compiletests.rs
+++ b/derive_builder/tests/compiletests.rs
@@ -1,30 +1,10 @@
-extern crate compiletest_rs as compiletest;
+extern crate rustversion;
+extern crate trybuild;
 
-use std::env;
-use std::path::PathBuf;
-
-fn run_mode(mode: &'static str) {
-    let base_dir = env!("CARGO_MANIFEST_DIR");
-
-    let test_dir = PathBuf::from(format!("{}/tests/{}", base_dir, mode));
-
-    if !test_dir.is_dir() {
-        panic!("Directory does not exist: {:?}", test_dir);
-    }
-
-    let mut config = compiletest::Config::default();
-    let cfg_mode = mode.parse().ok().expect("Invalid mode");
-
-    config.mode = cfg_mode;
-    config.src_base = test_dir;
-    config.link_deps();
-    config.clean_rmeta();
-
-    compiletest::run_tests(&config);
-}
-
+#[rustversion::stable(1.40)]
 #[test]
 fn compile_test() {
-    run_mode("run-pass");
-    run_mode("compile-fail");
+    let t = trybuild::TestCases::new();
+    t.pass("tests/run-pass/*.rs");
+    t.compile_fail("tests/compile-fail/*.rs");
 }

--- a/derive_builder_core/build/skeptic.rs
+++ b/derive_builder_core/build/skeptic.rs
@@ -55,7 +55,7 @@ use std::io::{Write, Read};
 const DOC_TPL_DIR: &'static str = "src/doc_tpl/";
 const DOC_TPL_OUT_DIR: &'static str = "doc_tpl/";
 
-fn generate_doc_tpl_tests() -> Result<Vec<String>, Box<Error>> {
+fn generate_doc_tpl_tests() -> Result<Vec<String>, Box<dyn Error>> {
     trace!("Generating doc template tests");
     let root_dir = PathBuf::from(env::var("CARGO_MANIFEST_DIR")?);
     let mut tpl_dir = root_dir;


### PR DESCRIPTION
I noticed that compiletest_rs is unstable. You need to run `cargo clean` from time to time to make it work. Its error messages are unreadable. Also I noticed that it doesn't work on macos.

Then I found [this](https://github.com/dtolnay/trybuild/issues/13).  :smirk:

I tested this on Linux and macos and it works well.