### PR TITLE
Fix requiring generic parameters to implement Default

### DIFF
--- a/derive_builder_core/src/builder_field.rs
+++ b/derive_builder_core/src/builder_field.rs
@@ -75,6 +75,14 @@ impl<'a> ToTokens for BuilderField<'a> {
     }
 }
 
+impl<'a> BuilderField<'a> {
+    /// Emits a struct field initializer that initializes the field to `Default::default`.
+    pub fn default_initializer_tokens(&self) -> TokenStream {
+        let ident = self.field_ident;
+        quote!{ #ident : ::derive_builder::export::core::default::Default::default(), }
+    }
+}
+
 /// Helper macro for unit tests. This is _only_ public in order to be accessible
 /// from doc-tests too.
 #[doc(hidden)]

--- a/derive_builder_core/src/macro_options/darling_opts.rs
+++ b/derive_builder_core/src/macro_options/darling_opts.rs
@@ -376,6 +376,7 @@ impl Options {
             generics: Some(&self.generics),
             visibility: self.builder_vis(),
             fields: Vec::with_capacity(self.field_count()),
+            field_initializers: Vec::with_capacity(self.field_count()),
             functions: Vec::with_capacity(self.field_count()),
             must_derive_clone: self.requires_clone(),
             doc_comment: None,


### PR DESCRIPTION
Currently the builder uses #[derive(Default)], which adds additional bounds to the type parameters
requiring them to implement Default. This is not required since the fields are all either `Option`
or `PhantomData`, which always have defaults, and means that Builders cannot be instantiated for
non-Default generics.

This commit makes the builder implement Default manually, without any additional bounds.