### PR TITLE
Update link to the builders pattern article

### DIFF
--- a/derive_builder/src/lib.rs
+++ b/derive_builder/src/lib.rs
@@ -542,7 +542,7 @@
 //! If possible please try to provide the debugging info if you experience unexpected
 //! compilation errors (see above).
 //!
-//! [builder pattern]: https://aturon.github.io/ownership/builders.html
+//! [builder pattern]: https://web.archive.org/web/20170701044756/https://aturon.github.io/ownership/builders.html
 //! [`derive_builder_core`]: https://crates.io/crates/derive_builder_core
 
 #![deny(warnings)]


### PR DESCRIPTION
Seems the original url https://aturon.github.io/ownership/builders.html is not working anymore. I found a working url on https://web.archive.org.