### PR TITLE
Shrink derive_builder_core's public API

### DIFF
--- a/derive_builder_core/src/block.rs
+++ b/derive_builder_core/src/block.rs
@@ -13,7 +13,7 @@ use syn;
 ///
 /// Will expand to something like the following (depending on settings):
 ///
-/// ```rust
+/// ```rust,ignore
 /// # #[macro_use]
 /// # extern crate quote;
 /// # extern crate derive_builder_core;

--- a/derive_builder_core/src/build_method.rs
+++ b/derive_builder_core/src/build_method.rs
@@ -1,4 +1,4 @@
-use doc_comment::doc_comment_from;
+use doc_comment_from;
 use proc_macro2::{Span, TokenStream};
 use quote::{ToTokens, TokenStreamExt};
 use syn;
@@ -14,7 +14,7 @@ use DEFAULT_STRUCT_NAME;
 ///
 /// Will expand to something like the following (depending on settings):
 ///
-/// ```rust
+/// ```rust,ignore
 /// # extern crate proc_macro2;
 /// # #[macro_use]
 /// # extern crate quote;

--- a/derive_builder_core/src/builder.rs
+++ b/derive_builder_core/src/builder.rs
@@ -3,7 +3,7 @@ use quote::{format_ident, ToTokens, TokenStreamExt};
 use syn::punctuated::Punctuated;
 use syn::{self, Path, TraitBound, TraitBoundModifier, TypeParamBound};
 
-use doc_comment::doc_comment_from;
+use doc_comment_from;
 use BuildMethod;
 use BuilderField;
 use BuilderPattern;
@@ -16,7 +16,7 @@ use Setter;
 ///
 /// Will expand to something like the following (depending on settings):
 ///
-/// ```rust
+/// ```rust,ignore
 /// # extern crate proc_macro2;
 /// # #[macro_use]
 /// # extern crate quote;
@@ -481,7 +481,7 @@ mod tests {
                             unimplemented!()
                         }
                     }
-                    
+
                     impl<'a, T: Debug + ::derive_builder::export::core::clone::Clone> ::derive_builder::export::core::default::Default for FooBuilder<'a, T> where T: PartialEq {
                         fn default() -> Self {
                             Self {
@@ -573,7 +573,7 @@ mod tests {
                             unimplemented!()
                         }
                     }
-                    
+
                     impl<'a, T: 'a + Default + ::derive_builder::export::core::clone::Clone> ::derive_builder::export::core::default::Default for FooBuilder<'a, T> where T: PartialEq {
                         fn default() -> Self {
                             Self {
@@ -662,7 +662,7 @@ mod tests {
                             unimplemented!()
                         }
                     }
-                    
+
                     impl<'a, T: Debug> ::derive_builder::export::core::default::Default for FooBuilder<'a, T>
                     where T: PartialEq {
                         fn default() -> Self {

--- a/derive_builder_core/src/builder_field.rs
+++ b/derive_builder_core/src/builder_field.rs
@@ -8,7 +8,7 @@ use syn;
 ///
 /// Will expand to something like the following (depending on settings):
 ///
-/// ```rust
+/// ```rust,ignore
 /// # extern crate proc_macro2;
 /// # #[macro_use]
 /// # extern crate quote;

--- a/derive_builder_core/src/deprecation_notes.rs
+++ b/derive_builder_core/src/deprecation_notes.rs
@@ -12,7 +12,7 @@ use syn;
 ///
 /// Will expand to something like the following (depending on settings):
 ///
-/// ```rust
+/// ```rust,ignore
 /// # #[macro_use]
 /// # extern crate quote;
 /// # extern crate derive_builder_core;
@@ -55,15 +55,9 @@ impl ToTokens for DeprecationNotes {
 
 impl DeprecationNotes {
     /// Appends a note to the collection.
+    #[cfg(test)]
     pub fn push(&mut self, note: String) {
         self.0.push(note)
-    }
-
-    /// Extend this collection with all values from another collection.
-    pub fn extend(&mut self, other: &Self) {
-        for x in &other.0 {
-            self.0.push(x.to_owned())
-        }
     }
 
     /// Create a view of these deprecation notes that can annotate a struct.

--- a/derive_builder_core/src/doc_comment.rs
+++ b/derive_builder_core/src/doc_comment.rs
@@ -6,7 +6,7 @@ use syn::Attribute;
 ///
 /// Will expand to something like the following (depending on inner value):
 ///
-/// ```rust
+/// ```rust,ignore
 /// # #[macro_use]
 /// # extern crate quote;
 /// # extern crate syn;

--- a/derive_builder_core/src/initializer.rs
+++ b/derive_builder_core/src/initializer.rs
@@ -13,7 +13,7 @@ use DEFAULT_STRUCT_NAME;
 ///
 /// Will expand to something like the following (depending on settings):
 ///
-/// ```rust
+/// ```rust,ignore
 /// # extern crate proc_macro2;
 /// # #[macro_use]
 /// # extern crate quote;

--- a/derive_builder_core/src/lib.rs
+++ b/derive_builder_core/src/lib.rs
@@ -4,20 +4,13 @@
 //!
 //! * You are probably looking for the [`derive_builder`] crate,
 //!   which wraps this crate and is much more ergonomic to use.
-//! * The API of this crate might **change frequently** in the near future.
-//!   The [`derive_builder`] crate also provides a much more stable API.
 //!
 //! ## Purpose
 //!
-//! This is an internal helper library of [`derive_builder`]. Its purpose is to
-//! allow [`derive_builder`] to use its own code generation technique, if
-//! needed.
+//! This is an internal helper library of [`derive_builder`], which allows for
+//! all the logic of builder creation to be decoupled from the proc-macro entry
+//! point.
 //!
-//! [`derive_builder_core`] might also be used in crates that
-//! [`derive_builder`] depends on - again to break a dependency cycle.
-//!
-//! If [`derive_builder`] does not itself depend on _your_ crate, then you
-//! should consider using [`derive_builder`] instead of [`derive_builder_core`].
 //!
 //! [`derive_builder`]: https://!crates.io/crates/derive_builder
 //! [`derive_builder_core`]: https://!crates.io/crates/derive_builder_core
@@ -49,16 +42,16 @@ mod macro_options;
 mod options;
 mod setter;
 
-pub use block::Block;
-pub use build_method::BuildMethod;
-pub use builder::Builder;
-pub use builder_field::BuilderField;
+pub(crate) use block::Block;
+pub(crate) use build_method::BuildMethod;
+pub(crate) use builder::Builder;
+pub(crate) use builder_field::BuilderField;
 use darling::FromDeriveInput;
-pub use deprecation_notes::DeprecationNotes;
-pub use doc_comment::doc_comment_from;
-pub use initializer::Initializer;
-pub use options::BuilderPattern;
-pub use setter::Setter;
+pub(crate) use deprecation_notes::DeprecationNotes;
+pub(crate) use doc_comment::doc_comment_from;
+pub(crate) use initializer::Initializer;
+pub(crate) use options::BuilderPattern;
+pub(crate) use setter::Setter;
 
 const DEFAULT_STRUCT_NAME: &str = "__default";
 

--- a/derive_builder_core/src/setter.rs
+++ b/derive_builder_core/src/setter.rs
@@ -13,7 +13,7 @@ use DeprecationNotes;
 ///
 /// Will expand to something like the following (depending on settings):
 ///
-/// ```rust
+/// ```rust,ignore
 /// # extern crate proc_macro2;
 /// # #[macro_use]
 /// # extern crate quote;


### PR DESCRIPTION
The only crate to depend on derive_builder_core is derive_builder. While it's useful that derive_builder_core is _able_ to export more than the derive function in the future, shrinking the API surface to be only the one function now means that adding builder features won't force semver bumps due to changes in the public-facing intermediate structs.

Because the structs are no longer public, doc-tests for those structs no longer compile. These are now ignored.