### PR TITLE
Custom error example

### DIFF
--- a/derive_builder/examples/custom_error.rs
+++ b/derive_builder/examples/custom_error.rs
@@ -12,7 +12,7 @@ use std::fmt;
 fn validate_age(builder: &ExampleBuilder) -> Result<(), Error> {
     match builder.age {
         Some(age) if age > 150 => Err(Error::UnrealisticAge(age)),
-        _ => Ok(())
+        _ => Ok(()),
     }
 }
 

--- a/derive_builder/examples/custom_error.rs
+++ b/derive_builder/examples/custom_error.rs
@@ -1,0 +1,52 @@
+//! This example shows using custom validation with a non-string error type.
+//!
+//! This relies on how the generated build function is constructed; the validator
+//! is invoked in conjunction with the `?` operator, so anything that converts to
+//! the generated `FooBuilderError` type is valid.
+
+#[macro_use]
+extern crate derive_builder;
+
+use std::fmt;
+
+fn validate_age(builder: &ExampleBuilder) -> Result<(), Error> {
+    match builder.age {
+        Some(age) if age > 150 => Err(Error::UnrealisticAge(age)),
+        _ => Ok(())
+    }
+}
+
+#[derive(Debug, Builder)]
+#[builder(setter(into), build_fn(validate = "validate_age"))]
+struct Example {
+    name: String,
+    age: usize,
+}
+
+enum Error {
+    UnrealisticAge(usize),
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        match self {
+            Self::UnrealisticAge(age) => write!(f, "Nobody is {} years old", age),
+        }
+    }
+}
+
+// Without this conversion, the example will fail to compile
+impl From<Error> for ExampleBuilderError {
+    fn from(error: Error) -> Self {
+        ExampleBuilderError::ValidationError(error.to_string())
+    }
+}
+
+fn main() {
+    let person_err = ExampleBuilder::default()
+        .name("Jane Doe")
+        .age(200usize)
+        .build()
+        .unwrap_err();
+    println!("{}", person_err);
+}

--- a/derive_builder/examples/custom_error_generic.rs
+++ b/derive_builder/examples/custom_error_generic.rs
@@ -1,0 +1,55 @@
+//! This example shows combining generics with custom errors and validation.
+//!
+//! Note the use of the type parameter in the `#[builder(...)]` attribute.
+
+#[macro_use]
+extern crate derive_builder;
+
+use derive_builder::UninitializedFieldError;
+
+trait Popular {
+    fn is_popular(&self) -> bool;
+}
+
+impl<'a> Popular for &'a str {
+    fn is_popular(&self) -> bool {
+        !self.starts_with('b')
+    }
+}
+
+#[derive(Debug, Builder)]
+#[builder(build_fn(validate = "check_person", error = "Error<N>"))]
+struct Person<N: Popular + Clone> {
+    name: N,
+    age: u16,
+}
+
+#[derive(Debug)]
+enum Error<N> {
+    UninitializedField(&'static str),
+    UnpopularName(N),
+}
+
+impl<N> From<UninitializedFieldError> for Error<N> {
+    fn from(error: UninitializedFieldError) -> Self {
+        Self::UninitializedField(error.field_name())
+    }
+}
+
+fn check_person<N: Popular + Clone>(builder: &PersonBuilder<N>) -> Result<(), Error<N>> {
+    if let Some(name) = &builder.name {
+        if !name.is_popular() {
+            return Err(Error::UnpopularName(name.clone()));
+        }
+    }
+
+    Ok(())
+}
+
+fn main() {
+    dbg!(PersonBuilder::default()
+        .name("bill")
+        .age(71)
+        .build()
+        .unwrap_err());
+}

--- a/derive_builder/src/lib.rs
+++ b/derive_builder/src/lib.rs
@@ -541,9 +541,13 @@
 #![deny(warnings)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
+extern crate derive_builder_core;
 extern crate derive_builder_macro;
 
 pub use derive_builder_macro::Builder;
+
+#[doc(inline)]
+pub use derive_builder_core::UninitializedFieldError;
 
 #[doc(hidden)]
 pub mod export {

--- a/derive_builder/tests/compile-fail/custom_error_generic_missing_bound.rs
+++ b/derive_builder/tests/compile-fail/custom_error_generic_missing_bound.rs
@@ -1,0 +1,44 @@
+#[macro_use]
+extern crate derive_builder;
+
+use derive_builder::UninitializedFieldError;
+
+trait Popular {
+    fn is_popular(&self) -> bool;
+}
+
+impl<'a> Popular for &'a str {
+    fn is_popular(&self) -> bool {
+        !self.starts_with('b')
+    }
+}
+
+#[derive(Debug, Builder)]
+#[builder(build_fn(validate = "check_person", error = "Error<N>"))]
+struct Person<N> {
+    name: N,
+    age: u16,
+}
+
+enum Error<N> {
+    UninitializedField(&'static str),
+    UnpopularName(N),
+}
+
+impl<N> From<UninitializedFieldError> for Error<N> {
+    fn from(error: UninitializedFieldError) -> Self {
+        Self::UninitializedField(error.field_name())
+    }
+}
+
+fn check_person<N: Popular + Clone>(builder: &PersonBuilder<N>) -> Result<(), Error<N>> {
+    if let Some(name) = &builder.name {
+        if !name.is_popular() {
+            return Err(Error::UnpopularName(name.clone()));
+        }
+    }
+
+    Ok(())
+}
+
+fn main() {}

--- a/derive_builder/tests/compile-fail/custom_error_generic_missing_bound.stderr
+++ b/derive_builder/tests/compile-fail/custom_error_generic_missing_bound.stderr
@@ -1,0 +1,10 @@
+error[E0277]: the trait bound `N: Popular` is not satisfied
+  --> $DIR/custom_error_generic_missing_bound.rs:17:31
+   |
+17 | #[builder(build_fn(validate = "check_person", error = "Error<N>"))]
+   |                               ^^^^^^^^^^^^^^ the trait `Popular` is not implemented for `N`
+18 | struct Person<N> {
+   |               - consider adding a `where N: Popular` bound
+...
+34 | fn check_person<N: Popular + Clone>(builder: &PersonBuilder<N>) -> Result<(), Error<N>> {
+   |    ------------    ------- required by this bound in `check_person`

--- a/derive_builder/tests/compile-fail/custom_error_no_from.rs
+++ b/derive_builder/tests/compile-fail/custom_error_no_from.rs
@@ -1,0 +1,37 @@
+#[macro_use]
+extern crate derive_builder;
+
+fn validate_age(age: usize) -> Result<(), Error> {
+    if age > 200 {
+        Err(Error::UnrealisticAge(age))
+    } else {
+        Ok(())
+    }
+}
+
+fn check_person(builder: &PersonBuilder) -> Result<(), Error> {
+    if let Some(age) = builder.age {
+        validate_age(age)
+    } else {
+        Ok(())
+    }
+}
+
+#[derive(Builder)]
+#[builder(build_fn(validate = "check_person", error = "Error"))]
+struct Person {
+    name: String,
+    age: usize,
+}
+
+// NOTE: This enum has a variant for the uninitialized field case (called MissingData)
+// but has forgotten `impl From<derive_builder::UninitializedFieldError>`, which is a
+// compile-blocking mistake.
+#[derive(Debug)]
+enum Error {
+    /// A required field is not filled out.
+    MissingData(&'static str),
+    UnrealisticAge(usize),
+}
+
+fn main() {}

--- a/derive_builder/tests/compile-fail/custom_error_no_from.stderr
+++ b/derive_builder/tests/compile-fail/custom_error_no_from.stderr
@@ -1,8 +1,8 @@
 error[E0277]: the trait bound `Error: std::convert::From<derive_builder::UninitializedFieldError>` is not satisfied
-  --> $DIR/custom_error_no_from.rs:20:10
+  --> $DIR/custom_error_no_from.rs:21:55
    |
-20 | #[derive(Builder)]
-   |          ^^^^^^^ the trait `std::convert::From<derive_builder::UninitializedFieldError>` is not implemented for `Error`
+21 | #[builder(build_fn(validate = "check_person", error = "Error"))]
+   |                                                       ^^^^^^^ the trait `std::convert::From<derive_builder::UninitializedFieldError>` is not implemented for `Error`
    |
    = note: required because of the requirements on the impl of `std::convert::Into<Error>` for `derive_builder::UninitializedFieldError`
    = note: required by `std::convert::Into::into`

--- a/derive_builder/tests/compile-fail/custom_error_no_from.stderr
+++ b/derive_builder/tests/compile-fail/custom_error_no_from.stderr
@@ -1,0 +1,8 @@
+error[E0277]: the trait bound `Error: std::convert::From<derive_builder::UninitializedFieldError>` is not satisfied
+  --> $DIR/custom_error_no_from.rs:20:10
+   |
+20 | #[derive(Builder)]
+   |          ^^^^^^^ the trait `std::convert::From<derive_builder::UninitializedFieldError>` is not implemented for `Error`
+   |
+   = note: required because of the requirements on the impl of `std::convert::Into<Error>` for `derive_builder::UninitializedFieldError`
+   = note: required by `std::convert::Into::into`

--- a/derive_builder/tests/custom_default.rs
+++ b/derive_builder/tests/custom_default.rs
@@ -4,6 +4,7 @@ extern crate pretty_assertions;
 extern crate derive_builder;
 
 mod field_level {
+    use derive_builder::UninitializedFieldError;
     #[derive(Debug, PartialEq, Default, Builder, Clone)]
     struct Lorem {
         required: String,
@@ -16,7 +17,7 @@ mod field_level {
         #[builder(default = r#"format!("{}-{}-{}-{}",
                              Clone::clone(self.required
                                 .as_ref()
-                                .ok_or("required must be initialized")?),
+                                .ok_or_else(|| UninitializedFieldError::new("required"))?),
                              match self.explicit_default { Some(ref x) => x, None => "EMPTY" },
                              self.escaped_default.as_ref().map(|x| x.as_ref()).unwrap_or("EMPTY"),
                              if let Some(ref x) = self.raw_default { x } else { "EMPTY" })"#)]

--- a/derive_builder/tests/run-pass/custom_error_default.rs
+++ b/derive_builder/tests/run-pass/custom_error_default.rs
@@ -1,0 +1,49 @@
+//! This test ensures custom errors don't need a conversion from `UninitializedFieldError`
+//! if uninitialized fields are impossible.
+
+#[macro_use]
+extern crate derive_builder;
+
+#[derive(Default, Builder)]
+#[builder(default, build_fn(validate = "check_person", error = "Error"))]
+struct Person {
+    name: String,
+    age: u16,
+}
+
+/// An error that deliberately doesn't have `impl From<UninitializedFieldError>`; as long
+/// as `PersonBuilder` uses `Person::default` then missing field errors are never possible.
+enum Error {
+    UnpopularName(String),
+    UnrealisticAge(u16),
+}
+
+fn check_age_realistic(age: u16) -> Result<(), Error> {
+    if age > 150 {
+        Err(Error::UnrealisticAge(age))
+    } else {
+        Ok(())
+    }
+}
+
+fn check_name_popular(name: &str) -> Result<(), Error> {
+    if name.starts_with('B') {
+        Err(Error::UnpopularName(name.to_string()))
+    } else {
+        Ok(())
+    }
+}
+
+fn check_person(builder: &PersonBuilder) -> Result<(), Error> {
+    if let Some(age) = &builder.age {
+        check_age_realistic(*age)?;
+    }
+
+    if let Some(name) = &builder.name {
+        check_name_popular(name)?;
+    }
+
+    Ok(())
+}
+
+fn main() {}

--- a/derive_builder_core/src/build_method.rs
+++ b/derive_builder_core/src/build_method.rs
@@ -2,6 +2,7 @@ use doc_comment_from;
 use proc_macro2::{Span, TokenStream};
 use quote::{ToTokens, TokenStreamExt};
 use syn;
+use syn::spanned::Spanned;
 use Block;
 use BuilderPattern;
 use Initializer;
@@ -81,7 +82,10 @@ impl<'a> ToTokens for BuildMethod<'a> {
             let ident = syn::Ident::new(DEFAULT_STRUCT_NAME, Span::call_site());
             quote!(let #ident: #target_ty #target_ty_generics = #default_expr;)
         });
-        let validate_fn = self.validate_fn.as_ref().map(|vfn| quote!(#vfn(&self)?;));
+        let validate_fn = self
+            .validate_fn
+            .as_ref()
+            .map(|vfn| quote_spanned!(vfn.span() => #vfn(&self)?;));
         let error_ty = &self.error_ty;
 
         if self.enabled {

--- a/derive_builder_core/src/build_method.rs
+++ b/derive_builder_core/src/build_method.rs
@@ -52,7 +52,7 @@ pub struct BuildMethod<'a> {
     /// Type parameters and lifetimes attached to this builder struct.
     pub target_ty_generics: Option<syn::TypeGenerics<'a>>,
     /// Type of error.
-    pub error_ty: syn::Ident,
+    pub error_ty: syn::Path,
     /// Field initializers for the target type.
     pub initializers: Vec<TokenStream>,
     /// Doc-comment of the builder struct.
@@ -123,6 +123,11 @@ impl<'a> BuildMethod<'a> {
     }
 }
 
+// pub struct BuildMethodError {
+//     is_generated: bool,
+//     ident: syn::Ident,
+// }
+
 /// Helper macro for unit tests. This is _only_ public in order to be accessible
 /// from doc-tests too.
 #[doc(hidden)]
@@ -136,7 +141,7 @@ macro_rules! default_build_method {
             pattern: BuilderPattern::Mutable,
             target_ty: &syn::Ident::new("Foo", ::proc_macro2::Span::call_site()),
             target_ty_generics: None,
-            error_ty: syn::Ident::new("FooBuilderError", ::proc_macro2::Span::call_site()),
+            error_ty: syn::parse_quote!(FooBuilderError),
             initializers: vec![quote!(foo: self.foo,)],
             doc_comment: None,
             default_struct: None,

--- a/derive_builder_core/src/builder.rs
+++ b/derive_builder_core/src/builder.rs
@@ -196,9 +196,9 @@ impl<'a> ToTokens for Builder<'a> {
                     ValidationError(String),
                 }
 
-                impl ::derive_builder::export::core::convert::From<&'static str> for #builder_error_ident {
-                    fn from(s: &'static str) -> Self {
-                        Self::UninitializedField(s)
+                impl ::derive_builder::export::core::convert::From<::derive_builder::UninitializedFieldError> for #builder_error_ident {
+                    fn from(s: ::derive_builder::UninitializedFieldError) -> Self {
+                        Self::UninitializedField(s.field_name())
                     }
                 }
 

--- a/derive_builder_core/src/error.rs
+++ b/derive_builder_core/src/error.rs
@@ -1,0 +1,32 @@
+use std::{error::Error, fmt};
+
+/// Runtime error when a `build()` method is called and one or more required fields
+/// do not have a value.
+#[derive(Debug, Clone)]
+pub struct UninitializedFieldError(&'static str);
+
+impl UninitializedFieldError {
+    /// Create a new `UnitializedFieldError` for the specified field name.
+    pub fn new(field_name: &'static str) -> Self {
+        UninitializedFieldError(field_name)
+    }
+
+    /// Get the name of the first-declared field that wasn't initialized
+    pub fn field_name(&self) -> &'static str {
+        self.0
+    }
+}
+
+impl fmt::Display for UninitializedFieldError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "Field not initialized: {}", self.0)
+    }
+}
+
+impl Error for UninitializedFieldError {}
+
+impl From<&'static str> for UninitializedFieldError {
+    fn from(field_name: &'static str) -> Self {
+        Self::new(field_name)
+    }
+}

--- a/derive_builder_core/src/initializer.rs
+++ b/derive_builder_core/src/initializer.rs
@@ -100,7 +100,10 @@ impl<'a> Initializer<'a> {
                 if self.use_default_struct {
                     MatchNone::UseDefaultStructField(self.field_ident)
                 } else {
-                    MatchNone::ReturnError(self.field_ident.to_string(), self.custom_error_type_span)
+                    MatchNone::ReturnError(
+                        self.field_ident.to_string(),
+                        self.custom_error_type_span,
+                    )
                 }
             }
         }

--- a/derive_builder_core/src/initializer.rs
+++ b/derive_builder_core/src/initializer.rs
@@ -133,8 +133,12 @@ impl<'a> ToTokens for MatchNone<'a> {
                     None => #struct_ident.#field_ident
                 ))
             }
-            MatchNone::ReturnError(ref err) => tokens.append_all(quote!(
-                None => return ::derive_builder::export::core::result::Result::Err(::derive_builder::export::core::convert::Into::into(#err))
+            MatchNone::ReturnError(ref field_name) => tokens.append_all(quote!(
+                None => return ::derive_builder::export::core::result::Result::Err(
+                    ::derive_builder::export::core::convert::Into::into(
+                        ::derive_builder::UninitializedFieldError::from(#field_name)
+                    )
+                )
             )),
         }
     }

--- a/derive_builder_core/src/initializer.rs
+++ b/derive_builder_core/src/initializer.rs
@@ -195,7 +195,7 @@ mod tests {
                 foo: match self.foo {
                     Some(ref value) => ::derive_builder::export::core::clone::Clone::clone(value),
                     None => return ::derive_builder::export::core::result::Result::Err(::derive_builder::export::core::convert::Into::into(
-                        "foo"
+                        ::derive_builder::UninitializedFieldError::from("foo")
                     )),
                 },
             )
@@ -214,7 +214,7 @@ mod tests {
                 foo: match self.foo {
                     Some(ref value) => ::derive_builder::export::core::clone::Clone::clone(value),
                     None => return ::derive_builder::export::core::result::Result::Err(::derive_builder::export::core::convert::Into::into(
-                        "foo"
+                        ::derive_builder::UninitializedFieldError::from("foo")
                     )),
                 },
             )
@@ -233,7 +233,7 @@ mod tests {
                 foo: match self.foo {
                     Some(value) => value,
                     None => return ::derive_builder::export::core::result::Result::Err(::derive_builder::export::core::convert::Into::into(
-                        "foo"
+                        ::derive_builder::UninitializedFieldError::from("foo")
                     )),
                 },
             )
@@ -296,7 +296,7 @@ mod tests {
                 foo: match self.foo {
                     Some(ref value) => ::derive_builder::export::core::clone::Clone::clone(value),
                     None => return ::derive_builder::export::core::result::Result::Err(::derive_builder::export::core::convert::Into::into(
-                        "foo"
+                        ::derive_builder::UninitializedFieldError::from("foo")
                     )),
                 },
             )

--- a/derive_builder_core/src/lib.rs
+++ b/derive_builder_core/src/lib.rs
@@ -37,10 +37,13 @@ mod builder;
 mod builder_field;
 mod deprecation_notes;
 mod doc_comment;
+mod error;
 mod initializer;
 mod macro_options;
 mod options;
 mod setter;
+
+pub use error::UninitializedFieldError;
 
 pub(crate) use block::Block;
 pub(crate) use build_method::BuildMethod;

--- a/derive_builder_core/src/macro_options/darling_opts.rs
+++ b/derive_builder_core/src/macro_options/darling_opts.rs
@@ -5,7 +5,7 @@ use crate::BuildMethod;
 use darling::util::{Flag, PathList};
 use darling::{self, FromMeta};
 use proc_macro2::Span;
-use syn::{self, Attribute, Generics, Ident, Path, Visibility};
+use syn::{self, spanned::Spanned, Attribute, Generics, Ident, Path, Visibility};
 
 use crate::macro_options::DefaultExpression;
 use crate::{Builder, BuilderField, BuilderPattern, DeprecationNotes, Initializer, Setter};
@@ -569,6 +569,12 @@ impl<'a> FieldWithDefaults<'a> {
                 .as_ref()
                 .map(|x| x.parse_block(self.parent.no_std.into())),
             use_default_struct: self.use_parent_default(),
+            custom_error_type_span: self
+                .parent
+                .build_fn
+                .error
+                .as_ref()
+                .map(|err_ty| err_ty.span()),
         }
     }
 

--- a/derive_builder_core/src/macro_options/darling_opts.rs
+++ b/derive_builder_core/src/macro_options/darling_opts.rs
@@ -50,8 +50,13 @@ pub struct BuildFn {
     /// method.
     ///
     /// # Type Bounds
-    /// This error type must `impl From<UninitializedFieldError>` and must support conversion
-    /// from the error returned by the `validate` function if one was specified.
+    /// This type's bounds depend on other settings of the builder.
+    ///
+    /// * If uninitialized fields cause `build()` to fail, then this type
+    ///   must `impl From<UninitializedFieldError>`. Uninitialized fields do not cause errors
+    ///   when default values are provided for every field or at the struct level.
+    /// * If `validate` is specified, then this type must provide a conversion from the specified
+    ///   function's error type.
     error: Option<Path>,
 }
 


### PR DESCRIPTION
@andy128k this is an interesting example of using custom validation errors today. For #181, we'd need a way for this to work without the heap allocation of `String`, which is what's driving #191.