### PR TITLE
Only generate ValidationError when needed

### DIFF
--- a/derive_builder/CHANGELOG.md
+++ b/derive_builder/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+- Only generate a validation error variant when necessary #201
+
 ## [0.10.0] - 2021-03-31
 - Requires Rust 1.40.0 or newer (was 1.37.0) #169
 - Logging feature is removed #177

--- a/derive_builder/src/lib.rs
+++ b/derive_builder/src/lib.rs
@@ -342,22 +342,26 @@
 //! ```rust
 //! # #[macro_use]
 //! # extern crate derive_builder;
+//! # use derive_builder::UninitializedFieldError;
 //! #
 //! # #[derive(Builder, PartialEq, Debug)]
 //! struct Lorem {
 //!     ipsum: String,
 //!     // Custom defaults can delegate to helper methods
 //!     // and pass errors to the enclosing `build()` method via `?`.
+//!     //
+//!     // When doing this, it is recommended that you use a custom error type
+//!     // unless you are only returning UninitializedFieldError.
 //!     #[builder(default = "self.default_dolor()?")]
 //!     dolor: String,
 //! }
 //!
 //! impl LoremBuilder {
 //!     // Private helper method with access to the builder struct.
-//!     fn default_dolor(&self) -> Result<String, String> {
+//!     fn default_dolor(&self) -> Result<String, UninitializedFieldError> {
 //!         match self.ipsum {
-//!             Some(ref x) if x.chars().count() > 3 => Ok(format!("dolor {}", x)),
-//!             _ => Err("ipsum must at least 3 chars to build dolor".to_string()),
+//!             Some(ref x) => Ok(format!("dolor {}", x)),
+//!             _ => Err(UninitializedFieldError::new("ipsum")),
 //!         }
 //!     }
 //! }

--- a/derive_builder_core/src/block.rs
+++ b/derive_builder_core/src/block.rs
@@ -67,7 +67,7 @@ mod test {
     use super::*;
 
     #[test]
-    #[should_panic(expected = r#"LexError"#)]
+    #[should_panic]
     fn block_invalid_token_trees() {
         Block::from_str("let x = 2; { x+1").unwrap();
     }

--- a/derive_builder_core/src/builder.rs
+++ b/derive_builder_core/src/builder.rs
@@ -375,13 +375,13 @@ mod tests {
                     /// Custom validation error
                     ValidationError(::std::string::String),
                 }
-    
+
                 impl ::derive_builder::export::core::convert::From<::derive_builder::UninitializedFieldError> for FooBuilderError {
                     fn from(s: ::derive_builder::UninitializedFieldError) -> Self {
                         Self::UninitializedField(s.field_name())
                     }
                 }
-    
+
                 impl ::derive_builder::export::core::fmt::Display for FooBuilderError {
                     fn fmt(&self, f: &mut ::derive_builder::export::core::fmt::Formatter) -> ::derive_builder::export::core::fmt::Result {
                         match self {
@@ -390,7 +390,7 @@ mod tests {
                         }
                     }
                 }
-    
+
                 #[cfg(not(no_std))]
                 impl ::std::error::Error for FooBuilderError {}
 
@@ -409,13 +409,13 @@ mod tests {
                     /// Uninitialized field
                     UninitializedField(&'static str),
                 }
-    
+
                 impl ::derive_builder::export::core::convert::From<::derive_builder::UninitializedFieldError> for FooBuilderError {
                     fn from(s: ::derive_builder::UninitializedFieldError) -> Self {
                         Self::UninitializedField(s.field_name())
                     }
                 }
-    
+
                 impl ::derive_builder::export::core::fmt::Display for FooBuilderError {
                     fn fmt(&self, f: &mut ::derive_builder::export::core::fmt::Formatter) -> ::derive_builder::export::core::fmt::Result {
                         match self {
@@ -423,7 +423,7 @@ mod tests {
                         }
                     }
                 }
-    
+
                 #[cfg(not(no_std))]
                 impl ::std::error::Error for FooBuilderError {}
             ));
@@ -469,7 +469,12 @@ mod tests {
                     }
                 ));
 
-                add_generated_error(&mut result, GeneratedError { validation_error: true });
+                add_generated_error(
+                    &mut result,
+                    GeneratedError {
+                        validation_error: true,
+                    },
+                );
 
                 result
             }
@@ -694,7 +699,12 @@ mod tests {
                     }
                 ));
 
-                add_generated_error(&mut result, GeneratedError { validation_error: true });
+                add_generated_error(
+                    &mut result,
+                    GeneratedError {
+                        validation_error: true,
+                    },
+                );
 
                 result
             }

--- a/derive_builder_core/src/lib.rs
+++ b/derive_builder_core/src/lib.rs
@@ -47,7 +47,7 @@ pub use error::UninitializedFieldError;
 
 pub(crate) use block::Block;
 pub(crate) use build_method::BuildMethod;
-pub(crate) use builder::Builder;
+pub(crate) use builder::{Builder, GeneratedError};
 pub(crate) use builder_field::BuilderField;
 use darling::FromDeriveInput;
 pub(crate) use deprecation_notes::DeprecationNotes;


### PR DESCRIPTION
Custom validation errors are converted to strings if the deriving struct doesn't specify a type for the errors returned by the `build` method. This variant was generated even when it wasn't needed, resulting in a reference to `String` that broke no_std.

This change only emits that variant when `build_fn(validate = "...")` is set **and** `build_fn(error = "...")` is not set. This means no_std will work in the simple case with no additional meta items needed.

Fixes #201