### PR TITLE
feat(into_builder): implement From trait for builder

### DIFF
--- a/derive_builder/src/lib.rs
+++ b/derive_builder/src/lib.rs
@@ -504,6 +504,46 @@
 //! # fn main() {}
 //! ```
 //!
+//! ## Create builder from instance
+//!
+//! `#[derive(Builder)]` implements the [`From`] trait for the builder, e.g. `From<Lorem> for LoremBuilder`.
+//!
+//! This allows you to convert an instance to a builder, update fields, and construct an instance again.
+//!
+//! ```rust
+//! # #[macro_use]
+//! # extern crate derive_builder;
+//! #
+//! #[derive(Builder, Debug, PartialEq)]
+//! struct Lorem {
+//!     pub ipsum: u32,
+//!     pub dolor: u32,
+//! }
+//!
+//! fn main() {
+//!     let lorem = LoremBuilder::default()
+//!         .ipsum(1u32)
+//!         .dolor(42u32)
+//!         .build()
+//!         .unwrap();
+//!
+//!     let mut builder: LoremBuilder = lorem.into();
+//!
+//!     let lorem = builder
+//!         .ipsum(2u32)
+//!         .build()
+//!         .unwrap();
+//!
+//!     assert_eq!(
+//!         lorem,
+//!         Lorem {
+//!             ipsum: 2,
+//!             dolor: 42
+//!         }
+//!     );
+//! }
+//! ```
+//!
 //! # **`#![no_std]`** Support (on Nightly)
 //!
 //! You can activate support for `#![no_std]` by adding `#[builder(no_std)]` to your struct

--- a/derive_builder/tests/builder_into.rs
+++ b/derive_builder/tests/builder_into.rs
@@ -1,0 +1,35 @@
+#[macro_use]
+extern crate pretty_assertions;
+#[macro_use]
+extern crate derive_builder;
+
+#[derive(Debug, PartialEq, Default, Builder, Clone)]
+#[builder(setter(into, strip_option))]
+struct Lorem {
+    pub ipsum: String,
+    pub dolor: Option<String>,
+    #[builder(setter(skip), default = "4")]
+    pub sit: u32,
+}
+
+#[test]
+fn builder_into() {
+    let lorem: Lorem = LoremBuilder::default()
+        .ipsum("Foo")
+        .dolor("Bar")
+        .build()
+        .unwrap();
+
+    let mut builder: LoremBuilder = lorem.into();
+
+    let lorem: Lorem = builder.ipsum("Baz").build().unwrap();
+
+    assert_eq!(
+        lorem,
+        Lorem {
+            ipsum: "Baz".to_owned(),
+            dolor: Some("Bar".to_owned()),
+            sit: 4
+        }
+    );
+}

--- a/derive_builder_core/src/builder.rs
+++ b/derive_builder_core/src/builder.rs
@@ -95,6 +95,14 @@ use Setter;
 ///     }
 /// }
 ///
+/// impl ::derive_builder::export::core::convert::From<Foo> for FooBuilder {
+///     fn from(value: Foo) -> Self {
+///         Self {
+///             foo: Some(value.foo),
+///         }
+///     }
+/// }
+///
 /// #           ));
 /// #           result
 /// #       }.to_string()

--- a/derive_builder_core/src/builder_field.rs
+++ b/derive_builder_core/src/builder_field.rs
@@ -76,6 +76,18 @@ impl<'a> BuilderField<'a> {
         let ident = self.field_ident;
         quote! { #ident : ::derive_builder::export::core::default::Default::default(), }
     }
+
+    /// Emits a builder field initializer that initializes the field to `Some(source.field)` or
+    /// `Default::default` in the case the field is not enabled.
+    /// Used to turn an instance of `Struct` back into a builder.
+    pub fn to_builder_initializer_tokens(&self) -> TokenStream {
+        if self.field_enabled {
+            let ident = self.field_ident;
+            quote! { #ident : Some(value.#ident), }
+        } else {
+            self.default_initializer_tokens()
+        }
+    }
 }
 
 /// Helper macro for unit tests. This is _only_ public in order to be accessible

--- a/derive_builder_core/src/macro_options/darling_opts.rs
+++ b/derive_builder_core/src/macro_options/darling_opts.rs
@@ -389,6 +389,7 @@ impl Options {
     pub fn as_builder(&self) -> Builder {
         Builder {
             enabled: true,
+            struct_ident: &self.ident,
             ident: self.builder_ident(),
             pattern: self.pattern,
             derives: &self.derive,
@@ -396,6 +397,7 @@ impl Options {
             visibility: self.builder_vis(),
             fields: Vec::with_capacity(self.field_count()),
             field_initializers: Vec::with_capacity(self.field_count()),
+            field_to_builder_initializers: Vec::with_capacity(self.field_count()),
             functions: Vec::with_capacity(self.field_count()),
             generate_error: self.build_fn.error.is_none(),
             must_derive_clone: self.requires_clone(),


### PR DESCRIPTION
Implement `From<Foo> for FooBuilder` to allow creating a builder from an instance.
This is useful when you want to create a new, modified, instance from an existing one.

Issue: https://github.com/colin-kiegel/rust-derive-builder/issues/170 