### PR TITLE
Allow opting out of impl Default

### DIFF
--- a/derive_builder/examples/custom_constructor.rs
+++ b/derive_builder/examples/custom_constructor.rs
@@ -1,0 +1,70 @@
+#![allow(dead_code)]
+
+#[macro_use]
+extern crate derive_builder;
+
+#[derive(Clone)]
+pub enum ContentType {
+    Json,
+    Xml,
+}
+
+impl Default for ContentType {
+    fn default() -> Self {
+        Self::Json
+    }
+}
+
+#[derive(Builder)]
+#[builder(custom_constructor, build_fn(private, name = "fallible_build"))]
+pub struct ApiClient {
+    // To make sure `host` and `key` are not changed after creation, tell derive_builder
+    // to create the fields but not to generate setters.
+    #[builder(setter(custom))]
+    host: String,
+    #[builder(setter(custom))]
+    key: String,
+    // uncommenting this field will cause the unit-test below to fail
+    // baz: String,
+    #[builder(default)]
+    content_type: ContentType,
+}
+
+impl ApiClient {
+    pub fn new(host: impl Into<String>, key: impl Into<String>) -> ApiClientBuilder {
+        ApiClientBuilder {
+            host: Some(host.into()),
+            key: Some(key.into()),
+            ..ApiClientBuilder::create_empty()
+        }
+    }
+}
+
+impl ApiClientBuilder {
+    pub fn build(&self) -> ApiClient {
+        self.fallible_build()
+            .expect("All required fields were initialized")
+    }
+}
+
+fn main() {
+    ApiClient::new("hello", "world")
+        .content_type(ContentType::Xml)
+        .build();
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ApiClient;
+
+    /// If any required fields are added to ApiClient and ApiClient::new was not updated,
+    /// the field will be `None` when this "infallible" build method is called, resulting
+    /// in a panic. Panicking is appropriate here, since the author of the builder promised
+    /// the caller that it was safe to call new(...) followed immediately by build(), and
+    /// the builder author is also the person who can correct the coding error by setting
+    /// a default for the new property or changing the signature of `new`
+    #[test]
+    fn api_client_new_collects_all_required_fields() {
+        ApiClient::new("hello", "world").build();
+    }
+}

--- a/derive_builder/examples/custom_constructor.rs
+++ b/derive_builder/examples/custom_constructor.rs
@@ -3,7 +3,7 @@
 #[macro_use]
 extern crate derive_builder;
 
-#[derive(Clone)]
+#[derive(Debug, Clone)]
 pub enum ContentType {
     Json,
     Xml,
@@ -15,8 +15,12 @@ impl Default for ContentType {
     }
 }
 
-#[derive(Builder)]
-#[builder(custom_constructor, build_fn(private, name = "fallible_build"))]
+#[derive(Debug, Builder)]
+#[builder(
+    custom_constructor,
+    create_empty = "empty",
+    build_fn(private, name = "fallible_build")
+)]
 pub struct ApiClient {
     // To make sure `host` and `key` are not changed after creation, tell derive_builder
     // to create the fields but not to generate setters.
@@ -35,7 +39,7 @@ impl ApiClient {
         ApiClientBuilder {
             host: Some(host.into()),
             key: Some(key.into()),
-            ..ApiClientBuilder::create_empty()
+            ..ApiClientBuilder::empty()
         }
     }
 }
@@ -48,9 +52,9 @@ impl ApiClientBuilder {
 }
 
 fn main() {
-    ApiClient::new("hello", "world")
+    dbg!(ApiClient::new("hello", "world")
         .content_type(ContentType::Xml)
-        .build();
+        .build());
 }
 
 #[cfg(test)]

--- a/derive_builder/tests/custom_constructor.rs
+++ b/derive_builder/tests/custom_constructor.rs
@@ -1,0 +1,52 @@
+#[macro_use]
+extern crate pretty_assertions;
+#[macro_use]
+extern crate derive_builder;
+
+#[derive(Debug, PartialEq, Eq, Builder)]
+#[builder(custom_constructor, build_fn(private, name = "fallible_build"))]
+struct Request {
+    url: &'static str,
+    username: &'static str,
+    #[builder(default, setter(into))]
+    password: Option<&'static str>,
+}
+
+impl RequestBuilder {
+    pub fn new(url: &'static str, username: &'static str) -> Self {
+        Self {
+            url: Some(url),
+            username: Some(username),
+            ..Self::create_empty()
+        }
+    }
+
+    pub fn build(&self) -> Request {
+        self.fallible_build()
+            .expect("All required fields set upfront")
+    }
+}
+
+#[test]
+fn new_then_build_succeeds() {
+    assert_eq!(
+        RequestBuilder::new("...", "!!!").build(),
+        Request {
+            url: "...",
+            username: "!!!",
+            password: None
+        }
+    );
+}
+
+#[test]
+fn new_then_set_succeeds() {
+    assert_eq!(
+        RequestBuilder::new("...", "!!!").password("test").build(),
+        Request {
+            url: "...",
+            username: "!!!",
+            password: Some("test")
+        }
+    );
+}

--- a/derive_builder_core/src/builder.rs
+++ b/derive_builder_core/src/builder.rs
@@ -111,11 +111,16 @@ pub struct Builder<'a> {
     pub pattern: BuilderPattern,
     /// Traits to automatically derive on the builder type.
     pub derives: &'a [Path],
-    /// When true, generate `impl Default for #ident` which sets all fields to `None`.
+    /// When true, generate `impl Default for #ident` which calls the `create_empty` inherent method.
     ///
-    /// Builders unconditionally include a private inherent method, `create_empty`, which
-    /// `impl Default` will leverage if this is `true`.
+    /// Note that the name of `create_empty` can be overridden; see the `create_empty` field for more.
     pub impl_default: bool,
+    /// The identifier of the inherent method that creates a builder with all fields set to
+    /// `None` or `PhantomData`.
+    ///
+    /// This method will be invoked by `impl Default` for the builder, but it is also accessible
+    /// to `impl` blocks on the builder that expose custom constructors.
+    pub create_empty: syn::Ident,
     /// Type parameters and lifetimes attached to this builder's struct
     /// definition.
     pub generics: Option<&'a syn::Generics>,
@@ -162,6 +167,7 @@ impl<'a> ToTokens for Builder<'a> {
                 .unwrap_or((None, None, None));
             let builder_fields = &self.fields;
             let builder_field_initializers = &self.field_initializers;
+            let create_empty = &self.create_empty;
             let functions = &self.functions;
 
             // Create the comma-separated set of derived traits for the builder
@@ -204,7 +210,8 @@ impl<'a> ToTokens for Builder<'a> {
                     #(#functions)*
                     #deprecation_notes
 
-                    fn create_empty() -> Self {
+                    /// Create an empty builder, with all fields set to `None` or `PhantomData`.
+                    fn #create_empty() -> Self {
                         Self {
                             #(#builder_field_initializers)*
                         }
@@ -216,7 +223,7 @@ impl<'a> ToTokens for Builder<'a> {
                 tokens.append_all(quote!(
                     impl #impl_generics ::derive_builder::export::core::default::Default for #builder_ident #ty_generics #where_clause {
                         fn default() -> Self {
-                            Self::create_empty()
+                            Self::#create_empty()
                         }
                     }
                 ));
@@ -337,6 +344,7 @@ macro_rules! default_builder {
             pattern: Default::default(),
             derives: &vec![],
             impl_default: true,
+            create_empty: syn::Ident::new("create_empty", ::proc_macro2::Span::call_site()),
             generics: None,
             visibility: parse_quote!(pub),
             fields: vec![quote!(foo: u32,)],
@@ -356,6 +364,7 @@ mod tests {
     #[allow(unused_imports)]
     use super::*;
     use proc_macro2::TokenStream;
+    use syn::Ident;
 
     fn add_generated_error(result: &mut TokenStream) {
         result.append_all(quote!(
@@ -423,6 +432,7 @@ mod tests {
                             unimplemented!()
                         }
 
+                        /// Create an empty builder, with all fields set to `None` or `PhantomData`.
                         fn create_empty() -> Self {
                             Self {
                                 foo: ::derive_builder::export::core::default::Default::default(),
@@ -433,6 +443,59 @@ mod tests {
                     impl ::derive_builder::export::core::default::Default for FooBuilder {
                         fn default() -> Self {
                             Self::create_empty()
+                        }
+                    }
+                ));
+
+                add_generated_error(&mut result);
+
+                result
+            }
+            .to_string()
+        );
+    }
+
+    #[test]
+    fn rename_create_empty() {
+        let mut builder = default_builder!();
+        builder.create_empty = Ident::new("empty", proc_macro2::Span::call_site());
+
+        assert_eq!(
+            quote!(#builder).to_string(),
+            {
+                let mut result = quote!();
+
+                #[cfg(not(feature = "clippy"))]
+                result.append_all(quote!(#[allow(clippy::all)]));
+
+                result.append_all(quote!(
+                    #[derive(Clone)]
+                    pub struct FooBuilder {
+                        foo: u32,
+                    }
+                ));
+
+                #[cfg(not(feature = "clippy"))]
+                result.append_all(quote!(#[allow(clippy::all)]));
+
+                result.append_all(quote!(
+                    #[allow(dead_code)]
+                    impl FooBuilder {
+                        fn bar () -> {
+                            unimplemented!()
+                        }
+
+                        /// Create an empty builder, with all fields set to `None` or `PhantomData`.
+                        fn empty() -> Self {
+                            Self {
+                                foo: ::derive_builder::export::core::default::Default::default(),
+                            }
+                        }
+                    }
+
+                    impl ::derive_builder::export::core::default::Default for FooBuilder {
+                        fn default() -> Self {
+                            Self::empty()
                         }
                     }
                 ));
@@ -482,6 +545,7 @@ mod tests {
                             unimplemented!()
                         }
 
+                        /// Create an empty builder, with all fields set to `None` or `PhantomData`.
                         fn create_empty() -> Self {
                             Self {
                                 foo: ::derive_builder::export::core::default::Default::default(),
@@ -544,6 +608,7 @@ mod tests {
                             unimplemented!()
                         }
                         
+                        /// Create an empty builder, with all fields set to `None` or `PhantomData`.
                         fn create_empty() -> Self {
                             Self {
                                 foo: ::derive_builder::export::core::default::Default::default(),
@@ -603,6 +668,7 @@ mod tests {
                             unimplemented!()
                         }
 
+                        /// Create an empty builder, with all fields set to `None` or `PhantomData`.
                         fn create_empty() -> Self {
                             Self {
                                 foo: ::derive_builder::export::core::default::Default::default(),
@@ -664,6 +730,7 @@ mod tests {
                             unimplemented!()
                         }
 
+                        /// Create an empty builder, with all fields set to `None` or `PhantomData`.
                         fn create_empty() -> Self {
                             Self {
                                 foo: ::derive_builder::export::core::default::Default::default(),

--- a/derive_builder_core/src/macro_options/darling_opts.rs
+++ b/derive_builder_core/src/macro_options/darling_opts.rs
@@ -284,6 +284,9 @@ pub struct Options {
     #[darling(default)]
     derive: PathList,
 
+    #[darling(default)]
+    custom_constructor: Flag,
+
     /// Setter options applied to all field setters in the struct.
     #[darling(default)]
     setter: StructLevelSetter,
@@ -394,6 +397,10 @@ impl Options {
             ident: self.builder_ident(),
             pattern: self.pattern,
             derives: &self.derive,
+            impl_default: {
+                let custom_constructor: bool = self.custom_constructor.into();
+                !custom_constructor
+            },
             generics: Some(&self.generics),
             visibility: self.builder_vis(),
             fields: Vec::with_capacity(self.field_count()),

--- a/derive_builder_core/src/macro_options/darling_opts.rs
+++ b/derive_builder_core/src/macro_options/darling_opts.rs
@@ -253,6 +253,10 @@ impl FlagVisibility for Field {
     }
 }
 
+fn default_create_empty() -> Ident {
+    Ident::new("create_empty", Span::call_site())
+}
+
 #[derive(Debug, Clone, FromDeriveInput)]
 #[darling(
     attributes(builder),
@@ -286,6 +290,11 @@ pub struct Options {
 
     #[darling(default)]
     custom_constructor: Flag,
+
+    /// The ident of the inherent method which takes no arguments and returns
+    /// an instance of the builder with all fields empty.
+    #[darling(default = "default_create_empty")]
+    create_empty: Ident,
 
     /// Setter options applied to all field setters in the struct.
     #[darling(default)]
@@ -401,6 +410,7 @@ impl Options {
                 let custom_constructor: bool = self.custom_constructor.into();
                 !custom_constructor
             },
+            create_empty: self.create_empty.clone(),
             generics: Some(&self.generics),
             visibility: self.builder_vis(),
             fields: Vec::with_capacity(self.field_count()),


### PR DESCRIPTION
This adds `#[builder(custom_constructor)]` as a way to suppress the generation of `impl Default for FooBuilder`. The name is chosen to avoid confusion with `#[builder(default)]`, as that is about the usage of the struct-level default to fill in missing fields.

One positive emergent property from this is that it's easy to put the `new` method onto the target type, rather than the builder: `ApiClient::new(...)` rather than `ApiClientBuilder::new(...)`. This seems advantageous for managing the set of imports needed to use `ApiClient`.

One unexpected aspect is the need to add `#[builder(setter(custom))]` to each set-up-front field. While it does make the struct more verbose, I think it illustrates how many nuances there are to this behavior, and it ends up supporting the idea that this is something people should create for themselves on top of the tools `derive_builder` provides, rather than attempting to generate constructors entirely through attributes.

# Alternative API
This would also work: `#[builder(constructor(private, name = "create_empty))]`. That would remove the need to remember or dig out the `create_empty` method name each time, at the expensive of additional verbosity in the attribute declaration.

Fixes #227