### PR TITLE
Remove all uses of syn::parse_str

### DIFF
--- a/derive_builder_core/src/build_method.rs
+++ b/derive_builder_core/src/build_method.rs
@@ -138,7 +138,7 @@ macro_rules! default_build_method {
         BuildMethod {
             enabled: true,
             ident: &syn::Ident::new("build", ::proc_macro2::Span::call_site()),
-            visibility: syn::parse_str("pub").unwrap(),
+            visibility: syn::parse_quote!(pub),
             pattern: BuilderPattern::Mutable,
             target_ty: &syn::Ident::new("Foo", ::proc_macro2::Span::call_site()),
             target_ty_generics: None,
@@ -227,8 +227,7 @@ mod tests {
 
     #[test]
     fn validation() {
-        let validate_path: syn::Path = syn::parse_str("IpsumBuilder::validate")
-            .expect("Statically-entered path should be valid");
+        let validate_path: syn::Path = parse_quote!(IpsumBuilder::validate);
 
         let mut build_method: BuildMethod = default_build_method!();
         build_method.validate_fn = Some(&validate_path);

--- a/derive_builder_core/src/builder.rs
+++ b/derive_builder_core/src/builder.rs
@@ -298,7 +298,7 @@ impl<'a> Builder<'a> {
                 paren_token: None,
                 modifier: TraitBoundModifier::None,
                 lifetimes: None,
-                path: syn::parse_str("::derive_builder::export::core::clone::Clone").unwrap(),
+                path: syn::parse_quote!(::derive_builder::export::core::clone::Clone),
             });
 
             for typ in generics.type_params_mut() {
@@ -324,7 +324,7 @@ macro_rules! default_builder {
             pattern: Default::default(),
             derives: &vec![],
             generics: None,
-            visibility: syn::parse_str("pub").unwrap(),
+            visibility: parse_quote!(pub),
             fields: vec![quote!(foo: u32,)],
             field_initializers: vec![quote!(foo: ::derive_builder::export::core::default::Default::default(), )],
             functions: vec![quote!(fn bar() -> { unimplemented!() })],
@@ -432,9 +432,9 @@ mod tests {
     #[rustfmt::skip]
     #[test]
     fn generic() {
-        let ast: syn::DeriveInput = syn::parse_str(stringify!(
+        let ast: syn::DeriveInput = parse_quote! {
             struct Lorem<'a, T: Debug> where T: PartialEq { }
-        )).expect("Couldn't parse item");
+        };
         let generics = ast.generics;
         let mut builder = default_builder!();
         builder.generics = Some(&generics);
@@ -486,9 +486,9 @@ mod tests {
     #[rustfmt::skip]
     #[test]
     fn generic_reference() {
-        let ast: syn::DeriveInput = syn::parse_str(stringify!(
+        let ast: syn::DeriveInput = parse_quote! {
             struct Lorem<'a, T: 'a + Default> where T: PartialEq{ }
-        )).expect("Couldn't parse item");
+        };
 
         let generics = ast.generics;
         let mut builder = default_builder!();
@@ -544,9 +544,9 @@ mod tests {
     #[rustfmt::skip]
     #[test]
     fn owned_generic() {
-        let ast: syn::DeriveInput = syn::parse_str(stringify!(
+        let ast: syn::DeriveInput = parse_quote! {
             struct Lorem<'a, T: Debug> where T: PartialEq { }
-        )).expect("Couldn't parse item");
+        };
         let generics = ast.generics;
         let mut builder = default_builder!();
         builder.generics = Some(&generics);
@@ -605,7 +605,7 @@ mod tests {
 
     #[test]
     fn add_derives() {
-        let derives = vec![syn::parse_str("Serialize").unwrap()];
+        let derives = vec![parse_quote!(Serialize)];
         let mut builder = default_builder!();
         builder.derives = &derives;
 

--- a/derive_builder_core/src/builder_field.rs
+++ b/derive_builder_core/src/builder_field.rs
@@ -86,9 +86,9 @@ macro_rules! default_builder_field {
     () => {{
         BuilderField {
             field_ident: &syn::Ident::new("foo", ::proc_macro2::Span::call_site()),
-            field_type: &syn::parse_str("String").unwrap(),
+            field_type: &parse_quote!(String),
             field_enabled: true,
-            field_visibility: syn::parse_str("pub").unwrap(),
+            field_visibility: parse_quote!(pub),
             attrs: &[parse_quote!(#[some_attr])],
         }
     }};

--- a/derive_builder_core/src/macro_options/darling_opts.rs
+++ b/derive_builder_core/src/macro_options/darling_opts.rs
@@ -29,7 +29,7 @@ trait FlagVisibility {
     fn as_expressed_vis(&self) -> Option<Visibility> {
         match (self.public().is_some(), self.private().is_some()) {
             (true, true) => panic!("A field cannot be both public and private"),
-            (true, false) => Some(syn::parse_str("pub").unwrap()),
+            (true, false) => Some(syn::parse_quote!(pub)),
             (false, true) => Some(Visibility::Inherited),
             (false, false) => None,
         }
@@ -333,8 +333,7 @@ impl Options {
             return custom.clone();
         }
 
-        syn::parse_str(&format!("{}Builder", self.ident))
-            .expect("Struct name with Builder suffix should be an ident")
+        format_ident!("{}Builder", self.ident)
     }
 
     pub fn builder_error_ident(&self) -> Path {
@@ -481,7 +480,7 @@ impl<'a> FieldWithDefaults<'a> {
         let ident = &self.field.ident;
 
         if let Some(ref prefix) = self.setter_prefix() {
-            return syn::parse_str(&format!("{}_{}", prefix, ident.as_ref().unwrap())).unwrap();
+            return format_ident!("{}_{}", prefix, ident.as_ref().unwrap());
         }
 
         ident.clone().unwrap()
@@ -512,7 +511,7 @@ impl<'a> FieldWithDefaults<'a> {
         self.field
             .as_expressed_vis()
             .or_else(|| self.parent.as_expressed_vis())
-            .unwrap_or_else(|| syn::parse_str("pub").unwrap())
+            .unwrap_or_else(|| syn::parse_quote!(pub))
     }
 
     /// Get the ident of the input field. This is also used as the ident of the

--- a/derive_builder_core/src/setter.rs
+++ b/derive_builder_core/src/setter.rs
@@ -266,12 +266,12 @@ macro_rules! default_setter {
         Setter {
             setter_enabled: true,
             try_setter: false,
-            visibility: syn::parse_str("pub").unwrap(),
+            visibility: parse_quote!(pub),
             pattern: BuilderPattern::Mutable,
             attrs: &vec![],
             ident: syn::Ident::new("foo", ::proc_macro2::Span::call_site()),
             field_ident: &syn::Ident::new("foo", ::proc_macro2::Span::call_site()),
-            field_type: &syn::parse_str("Foo").unwrap(),
+            field_type: &parse_quote!(Foo),
             generic_into: false,
             strip_option: false,
             deprecation_notes: &Default::default(),
@@ -388,7 +388,7 @@ mod tests {
 
     #[test]
     fn strip_option() {
-        let ty = syn::parse_str("Option<Foo>").unwrap();
+        let ty = parse_quote!(Option<Foo>);
         let mut setter = default_setter!();
         setter.strip_option = true;
         setter.field_type = &ty;
@@ -412,7 +412,7 @@ mod tests {
 
     #[test]
     fn strip_option_into() {
-        let ty = syn::parse_str("Option<Foo>").unwrap();
+        let ty = parse_quote!(Option<Foo>);
         let mut setter = default_setter!();
         setter.strip_option = true;
         setter.generic_into = true;
@@ -561,18 +561,17 @@ mod tests {
 
     #[test]
     fn extract_type_from_option_on_simple_type() {
-        let ty_foo = syn::parse_str("Foo").unwrap();
+        let ty_foo = parse_quote!(Foo);
         assert_eq!(extract_type_from_option(&ty_foo), None);
 
         for s in vec![
-            "Option<Foo>",
-            "std::option::Option<Foo>",
-            "::std::option::Option<Foo>",
-            "core::option::Option<Foo>",
-            "::core::option::Option<Foo>",
+            parse_quote!(Option<Foo>),
+            parse_quote!(std::option::Option<Foo>),
+            parse_quote!(::std::option::Option<Foo>),
+            parse_quote!(core::option::Option<Foo>),
+            parse_quote!(::core::option::Option<Foo>),
         ] {
-            let ty_foo_opt = syn::parse_str(s).unwrap();
-            assert_eq!(extract_type_from_option(&ty_foo_opt), Some(&ty_foo));
+            assert_eq!(extract_type_from_option(&s), Some(&ty_foo));
         }
     }
 }


### PR DESCRIPTION
* Use parse_quote for literals, removing unwraps
* Use format_ident to preserve span data