### PR TITLE
darling: Bump dependency to 0.12.4

### DIFF
--- a/derive_builder_core/Cargo.toml
+++ b/derive_builder_core/Cargo.toml
@@ -17,7 +17,7 @@ readme = "README.md"
 clippy = []
 
 [dependencies]
-darling = "0.12.0"
+darling = "0.12.4"
 proc-macro2 = "1.0.24"
 quote = "1.0.8"
 syn = { version = "1.0.69", features = ["full", "extra-traits"] }


### PR DESCRIPTION
and_then appeared in darling 0.12.4.

Sorry for not spotting htis earlier.