### PR TITLE
Break out distribute_and_unnest_attrs

### DIFF
--- a/derive_builder_core/src/macro_options/darling_opts.rs
+++ b/derive_builder_core/src/macro_options/darling_opts.rs
@@ -288,6 +288,10 @@ fn distribute_and_unnest_attrs(
 ) -> darling::Result<()> {
     let mut errors = vec![];
 
+    for (name, list) in &*outputs {
+        assert!(list.is_empty(), "Output Vec for '{}' was not empty", name);
+    }
+
     for attr in input.drain(..) {
         let unnest = outputs
             .iter_mut()

--- a/derive_builder_core/src/macro_options/darling_opts.rs
+++ b/derive_builder_core/src/macro_options/darling_opts.rs
@@ -293,13 +293,13 @@ fn distribute_and_unnest_attrs(
     }
 
     for attr in input.drain(..) {
-        let unnest = outputs
+        let destination = outputs
             .iter_mut()
             .find(|(ptattr, _)| attr.path.is_ident(ptattr));
 
-        if let Some((_, unnest)) = unnest {
+        if let Some((_, destination)) = destination {
             match unnest_from_one_attribute(attr) {
-                Ok(n) => unnest.push(n),
+                Ok(n) => destination.push(n),
                 Err(e) => errors.push(e),
             }
         } else {


### PR DESCRIPTION
RFC, as discussed in https://github.com/colin-kiegel/rust-derive-builder/pull/241#issuecomment-1069346362   .  It seemed better to demonstrate it rather than talk in the abstract.

I think it has come out quite nicely.  In particular, removing the duplicated specification of the output field variables now means it's not possible to accidentally get the unnesting and copying information out of step.

But if you prefer the code the way it is, please do feel free to say so and just close this MR.