### PR TITLE
Add restricted visibility support to builders, build methods, setters, and fields

### DIFF
--- a/derive_builder/CHANGELOG.md
+++ b/derive_builder/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+- Allow restricted visibility using `vis = "..."` for builders, build methods, setters, and fields #247
+
 ## [0.11.1] - 2022-03-16
 - Forward `allow` and `cfg` attributes from the deriving struct to the builder and its impl block #222
 - Support passing attributes to the builder struct using `#[builder_struct_attr(...)]`

--- a/derive_builder/tests/compile-fail/vis_conflict.rs
+++ b/derive_builder/tests/compile-fail/vis_conflict.rs
@@ -1,0 +1,21 @@
+#[macro_use]
+extern crate derive_builder;
+
+#[derive(Builder)]
+#[builder(public, vis = "pub(crate)")]
+pub struct Example {
+    #[builder(public, private)]
+    field: String,
+}
+
+#[derive(Builder)]
+#[builder(public, vis = "pub(crate)", build_fn(private, public))]
+pub struct SecondExample {
+    #[builder(private, vis = "pub")]
+    a_field: String,
+}
+
+fn main() {
+    ExampleBuilder::default().build();
+    SecondExampleBuilder::default().build();
+}

--- a/derive_builder/tests/compile-fail/vis_conflict.stderr
+++ b/derive_builder/tests/compile-fail/vis_conflict.stderr
@@ -1,0 +1,41 @@
+error: `public` and `private` cannot be used together
+ --> tests/compile-fail/vis_conflict.rs:7:15
+  |
+7 |     #[builder(public, private)]
+  |               ^^^^^^
+
+error: `vis="..."` cannot be used with `public` or `private`
+ --> tests/compile-fail/vis_conflict.rs:5:25
+  |
+5 | #[builder(public, vis = "pub(crate)")]
+  |                         ^^^^^^^^^^^^
+
+error: `public` and `private` cannot be used together
+  --> tests/compile-fail/vis_conflict.rs:12:57
+   |
+12 | #[builder(public, vis = "pub(crate)", build_fn(private, public))]
+   |                                                         ^^^^^^
+
+error: `vis="..."` cannot be used with `public` or `private`
+  --> tests/compile-fail/vis_conflict.rs:14:30
+   |
+14 |     #[builder(private, vis = "pub")]
+   |                              ^^^^^
+
+error: `vis="..."` cannot be used with `public` or `private`
+  --> tests/compile-fail/vis_conflict.rs:12:25
+   |
+12 | #[builder(public, vis = "pub(crate)", build_fn(private, public))]
+   |                         ^^^^^^^^^^^^
+
+error[E0433]: failed to resolve: use of undeclared type `ExampleBuilder`
+  --> tests/compile-fail/vis_conflict.rs:19:5
+   |
+19 |     ExampleBuilder::default().build();
+   |     ^^^^^^^^^^^^^^ use of undeclared type `ExampleBuilder`
+
+error[E0433]: failed to resolve: use of undeclared type `SecondExampleBuilder`
+  --> tests/compile-fail/vis_conflict.rs:20:5
+   |
+20 |     SecondExampleBuilder::default().build();
+   |     ^^^^^^^^^^^^^^^^^^^^ use of undeclared type `SecondExampleBuilder`

--- a/derive_builder_core/src/build_method.rs
+++ b/derive_builder_core/src/build_method.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use doc_comment_from;
 use proc_macro2::{Span, TokenStream};
 use quote::{ToTokens, TokenStreamExt};
@@ -43,7 +45,7 @@ pub struct BuildMethod<'a> {
     /// Name of this build fn.
     pub ident: &'a syn::Ident,
     /// Visibility of the build method, e.g. `syn::Visibility::Public`.
-    pub visibility: syn::Visibility,
+    pub visibility: Cow<'a, syn::Visibility>,
     /// How the build method takes and returns `self` (e.g. mutably).
     pub pattern: BuilderPattern,
     /// Type of the target field.
@@ -138,7 +140,7 @@ macro_rules! default_build_method {
         BuildMethod {
             enabled: true,
             ident: &syn::Ident::new("build", ::proc_macro2::Span::call_site()),
-            visibility: syn::parse_quote!(pub),
+            visibility: ::std::borrow::Cow::Owned(syn::parse_quote!(pub)),
             pattern: BuilderPattern::Mutable,
             target_ty: &syn::Ident::new("Foo", ::proc_macro2::Span::call_site()),
             target_ty_generics: None,

--- a/derive_builder_core/src/builder.rs
+++ b/derive_builder_core/src/builder.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use proc_macro2::TokenStream;
 use quote::{format_ident, ToTokens, TokenStreamExt};
 use syn::punctuated::Punctuated;
@@ -110,7 +112,7 @@ pub struct Builder<'a> {
     /// definition.
     pub generics: Option<&'a syn::Generics>,
     /// Visibility of the builder struct, e.g. `syn::Visibility::Public`.
-    pub visibility: syn::Visibility,
+    pub visibility: Cow<'a, syn::Visibility>,
     /// Fields of the builder struct, e.g. `foo: u32,`
     ///
     /// Expects each entry to be terminated by a comma.
@@ -341,7 +343,7 @@ macro_rules! default_builder {
             impl_default: true,
             create_empty: syn::Ident::new("create_empty", ::proc_macro2::Span::call_site()),
             generics: None,
-            visibility: parse_quote!(pub),
+            visibility: ::std::borrow::Cow::Owned(parse_quote!(pub)),
             fields: vec![quote!(foo: u32,)],
             field_initializers: vec![quote!(foo: ::derive_builder::export::core::default::Default::default(), )],
             functions: vec![quote!(fn bar() -> { unimplemented!() })],

--- a/derive_builder_core/src/builder_field.rs
+++ b/derive_builder_core/src/builder_field.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+
 use proc_macro2::TokenStream;
 use quote::{ToTokens, TokenStreamExt};
 use syn;
@@ -42,7 +44,7 @@ pub struct BuilderField<'a> {
     ///       least for now.
     pub field_enabled: bool,
     /// Visibility of this builder field, e.g. `syn::Visibility::Public`.
-    pub field_visibility: syn::Visibility,
+    pub field_visibility: Cow<'a, syn::Visibility>,
     /// Attributes which will be attached to this builder field.
     pub attrs: &'a [syn::Attribute],
 }
@@ -88,7 +90,7 @@ macro_rules! default_builder_field {
             field_ident: &syn::Ident::new("foo", ::proc_macro2::Span::call_site()),
             field_type: &parse_quote!(String),
             field_enabled: true,
-            field_visibility: parse_quote!(pub),
+            field_visibility: ::std::borrow::Cow::Owned(parse_quote!(pub)),
             attrs: &[parse_quote!(#[some_attr])],
         }
     }};
@@ -129,7 +131,7 @@ mod tests {
 
     #[test]
     fn private_field() {
-        let private = syn::Visibility::Inherited;
+        let private = Cow::Owned(syn::Visibility::Inherited);
         let mut field = default_builder_field!();
         field.field_visibility = private;
 

--- a/derive_builder_core/src/setter.rs
+++ b/derive_builder_core/src/setter.rs
@@ -1,4 +1,6 @@
 #![allow(clippy::useless_let_if_seq)]
+use std::borrow::Cow;
+
 use proc_macro2::{Span, TokenStream};
 use quote::{ToTokens, TokenStreamExt};
 use syn;
@@ -43,7 +45,7 @@ pub struct Setter<'a> {
     /// Enables code generation for the `try_` variant of this setter fn.
     pub try_setter: bool,
     /// Visibility of the setter, e.g. `syn::Visibility::Public`.
-    pub visibility: syn::Visibility,
+    pub visibility: Cow<'a, syn::Visibility>,
     /// How the setter method takes and returns `self` (e.g. mutably).
     pub pattern: BuilderPattern,
     /// Attributes which will be attached to this setter fn.
@@ -266,7 +268,7 @@ macro_rules! default_setter {
         Setter {
             setter_enabled: true,
             try_setter: false,
-            visibility: parse_quote!(pub),
+            visibility: ::std::borrow::Cow::Owned(parse_quote!(pub)),
             pattern: BuilderPattern::Mutable,
             attrs: &vec![],
             ident: syn::Ident::new("foo", ::proc_macro2::Span::call_site()),
@@ -344,7 +346,7 @@ mod tests {
 
     #[test]
     fn private() {
-        let vis = syn::Visibility::Inherited;
+        let vis = Cow::Owned(syn::Visibility::Inherited);
 
         let mut setter = default_setter!();
         setter.visibility = vis;


### PR DESCRIPTION
* Use Cow&lt;syn::Visibility> to avoid unnecessary cloning
* Make as_expressed_vis return a Result
* Add Visibility::explicit

This will be updated for #246 soon.