### PR TITLE
Move compile-fail tests to rustc 1.59

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,8 @@ jobs:
           - nightly
           - beta
           - stable
-          - 1.40.0
+          - 1.40.0 # MSRV
+          - 1.59.0 # Used for trybuild; supports aarch64
         features:
           - ""
           - --no-default-features

--- a/derive_builder/Cargo.toml
+++ b/derive_builder/Cargo.toml
@@ -27,5 +27,5 @@ derive_builder_macro = { version = "=0.11.1", path = "../derive_builder_macro" }
 pretty_assertions = "0.6.1"
 rustversion = "1.0.4"
 trybuild = "1.0.38"
-serde = "1"
+serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/derive_builder/tests/compile-fail/builder_setter_attr.stderr
+++ b/derive_builder/tests/compile-fail/builder_setter_attr.stderr
@@ -4,7 +4,7 @@ error: unused return value of `LoremBuilder::broken` that must be used
 15 |     LoremBuilder::default().broken(42);
    |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
-note: lint level defined here
+note: the lint level is defined here
   --> tests/compile-fail/builder_setter_attr.rs:1:9
    |
 1  | #![deny(unused_must_use)]

--- a/derive_builder/tests/compile-fail/custom_error_generic_missing_bound.stderr
+++ b/derive_builder/tests/compile-fail/custom_error_generic_missing_bound.stderr
@@ -1,10 +1,15 @@
 error[E0277]: the trait bound `N: Popular` is not satisfied
-  --> $DIR/custom_error_generic_missing_bound.rs:17:31
+  --> tests/compile-fail/custom_error_generic_missing_bound.rs:17:31
    |
 17 | #[builder(build_fn(validate = "check_person", error = "Error<N>"))]
    |                               ^^^^^^^^^^^^^^ the trait `Popular` is not implemented for `N`
-18 | struct Person<N> {
-   |               - consider adding a `where N: Popular` bound
-...
+   |
+note: required by a bound in `check_person`
+  --> tests/compile-fail/custom_error_generic_missing_bound.rs:34:20
+   |
 34 | fn check_person<N: Popular + Clone>(builder: &PersonBuilder<N>) -> Result<(), Error<N>> {
-   |    ------------    ------- required by this bound in `check_person`
+   |                    ^^^^^^^ required by this bound in `check_person`
+help: consider restricting type parameter `N`
+   |
+18 | struct Person<N: Popular> {
+   |                +++++++++

--- a/derive_builder/tests/compile-fail/custom_error_no_from.stderr
+++ b/derive_builder/tests/compile-fail/custom_error_no_from.stderr
@@ -1,8 +1,7 @@
-error[E0277]: the trait bound `Error: std::convert::From<derive_builder::UninitializedFieldError>` is not satisfied
-  --> $DIR/custom_error_no_from.rs:21:55
+error[E0277]: the trait bound `Error: From<UninitializedFieldError>` is not satisfied
+  --> tests/compile-fail/custom_error_no_from.rs:21:55
    |
 21 | #[builder(build_fn(validate = "check_person", error = "Error"))]
-   |                                                       ^^^^^^^ the trait `std::convert::From<derive_builder::UninitializedFieldError>` is not implemented for `Error`
+   |                                                       ^^^^^^^ the trait `From<UninitializedFieldError>` is not implemented for `Error`
    |
-   = note: required because of the requirements on the impl of `std::convert::Into<Error>` for `derive_builder::UninitializedFieldError`
-   = note: required by `std::convert::Into::into`
+   = note: required because of the requirements on the impl of `Into<Error>` for `UninitializedFieldError`

--- a/derive_builder/tests/compile-fail/private_build_fn.stderr
+++ b/derive_builder/tests/compile-fail/private_build_fn.stderr
@@ -1,13 +1,16 @@
 warning: unused import: `Lorem`
-  --> $DIR/private_build_fn.rs:23:21
+  --> tests/compile-fail/private_build_fn.rs:23:21
    |
 23 |     use container::{Lorem, LoremBuilder};
    |                     ^^^^^
    |
    = note: `#[warn(unused_imports)]` on by default
 
-error[E0624]: method `build` is private
-  --> $DIR/private_build_fn.rs:27:42
+error[E0624]: associated function `build` is private
+  --> tests/compile-fail/private_build_fn.rs:27:42
    |
+7  |     #[derive(Debug, Default, Builder)]
+   |                              ------- private associated function defined here
+...
 27 |     let lorem2 = LoremBuilder::default().build().unwrap();
-   |                                          ^^^^^
+   |                                          ^^^^^ private associated function

--- a/derive_builder/tests/compile-fail/private_builder.stderr
+++ b/derive_builder/tests/compile-fail/private_builder.stderr
@@ -1,11 +1,21 @@
 error[E0603]: struct `LoremBuilder` is private
-  --> $DIR/private_builder.rs:17:18
+  --> tests/compile-fail/private_builder.rs:17:18
    |
 17 |     let x = foo::LoremBuilder::default()
-   |                  ^^^^^^^^^^^^
-
-error[E0624]: method `build` is private
-  --> $DIR/private_builder.rs:19:10
+   |                  ^^^^^^^^^^^^ private struct
    |
+note: the struct `LoremBuilder` is defined here
+  --> tests/compile-fail/private_builder.rs:7:41
+   |
+7  |     #[derive(Debug, PartialEq, Default, Builder, Clone)]
+   |                                         ^^^^^^^
+   = note: this error originates in the derive macro `Builder` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error[E0624]: associated function `build` is private
+  --> tests/compile-fail/private_builder.rs:19:10
+   |
+7  |     #[derive(Debug, PartialEq, Default, Builder, Clone)]
+   |                                         ------- private associated function defined here
+...
 19 |         .build()
-   |          ^^^^^
+   |          ^^^^^ private associated function

--- a/derive_builder/tests/compile-fail/private_fields.stderr
+++ b/derive_builder/tests/compile-fail/private_fields.stderr
@@ -1,5 +1,5 @@
-error[E0616]: field `dolor` of struct `inner::LoremBuilder` is private
-  --> $DIR/private_fields.rs:25:5
+error[E0616]: field `dolor` of struct `LoremBuilder` is private
+  --> tests/compile-fail/private_fields.rs:25:11
    |
 25 |     lorem.dolor = Some(0); // <-- private
-   |     ^^^^^^^^^^^
+   |           ^^^^^ private field

--- a/derive_builder/tests/compile-fail/rename_setter_struct_level.stderr
+++ b/derive_builder/tests/compile-fail/rename_setter_struct_level.stderr
@@ -1,11 +1,11 @@
 error: Unknown field: `name`
- --> $DIR/rename_setter_struct_level.rs:7:18
+ --> tests/compile-fail/rename_setter_struct_level.rs:7:18
   |
 7 | #[builder(setter(name = "foo"))]
   |                  ^^^^
 
-error[E0433]: failed to resolve: use of undeclared type or module `LoremBuilder`
-  --> $DIR/rename_setter_struct_level.rs:14:13
+error[E0433]: failed to resolve: use of undeclared type `LoremBuilder`
+  --> tests/compile-fail/rename_setter_struct_level.rs:14:13
    |
 14 |     let x = LoremBuilder::default()
-   |             ^^^^^^^^^^^^ use of undeclared type or module `LoremBuilder`
+   |             ^^^^^^^^^^^^ use of undeclared type `LoremBuilder`

--- a/derive_builder/tests/compiletests.rs
+++ b/derive_builder/tests/compiletests.rs
@@ -1,7 +1,7 @@
 extern crate rustversion;
 extern crate trybuild;
 
-#[rustversion::stable(1.40)]
+#[rustversion::stable(1.59)]
 #[test]
 fn compile_test() {
     let t = trybuild::TestCases::new();


### PR DESCRIPTION
This version works locally on M1 processors.