### PR TITLE
Update darling, proc-macro2, quote, and syn

### DIFF
--- a/derive_builder_core/Cargo.toml
+++ b/derive_builder_core/Cargo.toml
@@ -17,10 +17,10 @@ readme = "README.md"
 clippy = []
 
 [dependencies]
-darling = "0.12.4"
-proc-macro2 = "1.0.24"
-quote = "1.0.8"
-syn = { version = "1.0.69", features = ["full", "extra-traits"] }
+darling = "0.14.0"
+proc-macro2 = "1.0.37"
+quote = "1.0.18"
+syn = { version = "1.0.91", features = ["full", "extra-traits"] }
 
 [dev-dependencies]
 pretty_assertions = "0.6.1"

--- a/derive_builder_core/src/macro_options/darling_opts.rs
+++ b/derive_builder_core/src/macro_options/darling_opts.rs
@@ -28,7 +28,7 @@ trait FlagVisibility {
     /// # Panics
     /// This method panics if the input specifies both `public` and `private`.
     fn as_expressed_vis(&self) -> Option<Visibility> {
-        match (self.public().is_some(), self.private().is_some()) {
+        match (self.public().is_present(), self.private().is_present()) {
             (true, true) => panic!("A field cannot be both public and private"),
             (true, false) => Some(syn::parse_quote!(pub)),
             (false, true) => Some(Visibility::Inherited),
@@ -551,10 +551,7 @@ impl Options {
             derives: &self.derive,
             struct_attrs: &self.struct_attrs,
             impl_attrs: &self.impl_attrs,
-            impl_default: {
-                let custom_constructor: bool = self.custom_constructor.into();
-                !custom_constructor
-            },
+            impl_default: !self.custom_constructor.is_present(),
             create_empty: self.create_empty.clone(),
             generics: Some(&self.generics),
             visibility: self.builder_vis(),
@@ -565,10 +562,7 @@ impl Options {
             must_derive_clone: self.requires_clone(),
             doc_comment: None,
             deprecation_notes: Default::default(),
-            std: {
-                let no_std: bool = self.no_std.into();
-                !no_std
-            },
+            std: !self.no_std.is_present(),
         }
     }
 
@@ -620,7 +614,7 @@ impl<'a> FieldWithDefaults<'a> {
     /// Check if this field should emit a fallible setter.
     /// This depends on the `TryFrom` trait, which hasn't yet stabilized.
     pub fn try_setter(&self) -> bool {
-        self.field.try_setter.is_some() || self.parent.try_setter.is_some()
+        self.field.try_setter.is_present() || self.parent.try_setter.is_present()
     }
 
     /// Get the prefix that should be applied to the field name to produce

--- a/derive_builder_macro/Cargo.toml
+++ b/derive_builder_macro/Cargo.toml
@@ -22,5 +22,5 @@ proc-macro = true
 clippy = ["derive_builder_core/clippy"]
 
 [dependencies]
-syn = { version = "1.0.58", features = ["full", "extra-traits"] }
+syn = { version = "1.0.91", features = ["full", "extra-traits"] }
 derive_builder_core = { version = "=0.11.1", path = "../derive_builder_core" }


### PR DESCRIPTION
This lets us use:
* Faster compilation times courtesy of quote 1.0.18
* Implicit defaulting behavior of darling 0.14.0
* Updated `Flag` struct from darling 0.14.0 