### PR TITLE
Clarify as_expressed_vis

### DIFF
--- a/derive_builder_core/src/macro_options/darling_opts.rs
+++ b/derive_builder_core/src/macro_options/darling_opts.rs
@@ -31,7 +31,9 @@ trait Visibility {
     fn as_expressed_vis<'s>(&'s self) -> Option<Cow<'s, syn::Visibility>> {
         let mut to_return = None;
         let mut intend_return_some = |v: Cow<'s, syn::Visibility>| {
-            if let Some(already) = &to_return { panic!("visibility specified both of {:?} {:?}", already, &v); }
+            if let Some(already) = &to_return {
+                panic!("visibility specified both of {:?} {:?}", already, &v);
+            }
             to_return = Some(v);
         };
 


### PR DESCRIPTION
I found the old code confusing to read, since one has to pore through
it to see what the conditions for panicing are.

No functional change.

This is purely stylistic.  If you don't agree with my sense of taste here, please just close this MR :-).

Thanks.