### PR TITLE
Feature/post build operation

### DIFF
--- a/derive_builder/examples/post_build.rs
+++ b/derive_builder/examples/post_build.rs
@@ -1,0 +1,124 @@
+// some times, one or more fields of your struct need to be built according to other field's values
+// may be you have a layout which needs tpo know all other field's values to be built, or that you have some field that needs to be calculated only once for the struct
+// and you don't want to recalculate it every time one of the fields are set in the builder
+// There are several situations in which a post build event might be useful.
+// 1. You might have a field which needs to be calculated when the struct is built, but deppends on several other field values to calculate.
+// 2. You might want to trigger an event whenever a new struct of a given type is built, so that other components of your application can react.
+// 3. You might want to perform a complete validation which needs to know values of all fields to be performed.
+// The classical ways to solve this problem would be:
+// 1. call a method wich accepts &mut self in the target struct as soon as it is built. This method would make validations, trigger events, calculate fields.
+// The main issue with this strategy is one can easily forget to call the post build method or function, and even if they don't, this function is effectively finishing to build the struct, so it shouldn't be decoupled from the building process at all. This post build function or  method also shouldn't be part of the public api.
+// 2. Customize the setters of all fields affecting the field to be calculated and update it accordingly.
+// The main issue with this strategy is that This would make room for repeated code, might run an expensive calculation on all calls to affected setters and would couple the set of the calculated field with the setters of all the affected fields, all things we want to avoid.
+// The post_build parameter of build_fn allows you to provide a function or a method which gets called by the build() method of the builder struct as soon as the target struct is built.
+// this solves the proposed problem, creates great ergonomy and decouples the set of the calculated field and all other side effects you might want to add with the setters of other fields
+// In order to use post_build functionality, you can declare #[builder(build_fn(post_build = "path::to::fn"))] to specify a post build function which will be called as soon as the target struct is built, still inside the builder function. The path does not need to be fully-qualified, and will consider use statements made at module level. It must be accessible from the scope where the target struct is declared.
+// The provided function must have the signature (&mut Foo) -> Result<_, String>; the Ok variant is not used by the build method.
+
+use derive_builder::{PostBuildError, UninitializedFieldError};
+
+#[macro_use]
+extern crate derive_builder;
+
+#[derive(Debug, Clone, Builder, PartialEq, Eq)]
+#[builder(build_fn(post_build = "LoremBuilder::post_build"))]
+pub struct Lorem {
+    /// a number
+    number: i32,
+
+    /// big_number
+    /// this will be calculated by the post build function, so it should not (though mothing prevents it from) make a setter available.
+    /// It also should have a default value, either specified in the builder directive or delegated to the Default trait of the type
+    #[builder(setter(skip), default = "false")]
+    big_number: bool,
+}
+
+impl LoremBuilder {
+    /// performs post build operation
+    fn post_build(target: &mut Lorem) -> Result<(), String> {
+        // post build validation
+        if target.number <= 0 {
+            return Err("Number must be greater than 0".to_string());
+        }
+        // remember that we didn't set the big_number field. We deppend on the number field to decide if this instance has or hasn't a big number.
+        // This can only be safely known when the struct has just been built but nobody for sure yet used it
+        if target.number > 60 {
+            // initialize the big_number field
+            target.big_number = true;
+        }
+
+        Ok(())
+    }
+}
+
+// if you are using post build functionality, you need to provide a conversion  from PostBuildError for your custom error type
+#[derive(Builder, Debug, PartialEq)]
+#[builder(build_fn(
+    post_build = "LoremCustomErrorBuilder::post_build",
+    error = "OurLoremError"
+))]
+struct LoremCustomError {
+    /// a number
+    number: i32,
+
+    /// big_number
+    #[builder(setter(skip), default = "false")]
+    big_number: bool,
+}
+
+impl LoremCustomErrorBuilder {
+    /// performs post build operation
+    fn post_build(target: &mut LoremCustomError) -> Result<(), String> {
+        if target.number <= 0 {
+            return Err("Number must be greater than 0".to_string());
+        }
+        if target.number > 60 {
+            target.big_number = true;
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+struct OurLoremError(String);
+
+impl From<UninitializedFieldError> for OurLoremError {
+    fn from(ufe: UninitializedFieldError) -> OurLoremError {
+        OurLoremError(ufe.to_string())
+    }
+}
+
+impl From<PostBuildError> for OurLoremError {
+    fn from(pbe: PostBuildError) -> OurLoremError {
+        OurLoremError(format!("Custom build error: {}", pbe.get_msg()))
+    }
+}
+
+fn main() {
+    // post build does not modify the big_number default field value
+    let x = LoremBuilder::default().number(20).build().unwrap();
+    assert_eq!(x.big_number, false);
+
+    // post build modifies the big_number field value
+    let x = LoremBuilder::default().number(80).build().unwrap();
+    assert_eq!(x.big_number, true);
+
+    // post build validation fails
+    let x = LoremBuilder::default().number(-1).build().unwrap_err();
+    let correct_variant = match x {
+        LoremBuilderError::UninitializedField(_) => {
+            panic!("Should get a post builder error, got a uninitialized field error instead")
+        }
+        LoremBuilderError::PostBuildError(e) => true,
+        LoremBuilderError::ValidationError(_) => {
+            panic!("Should get a post builder error, got a validation error instead")
+        }
+    };
+    assert!(correct_variant);
+
+    // should get a custom error instance when using post build with a custom error
+    let x = LoremCustomErrorBuilder::default().number(-1).build();
+
+    assert!(x.is_err());
+}

--- a/derive_builder/src/error.rs
+++ b/derive_builder/src/error.rs
@@ -3,6 +3,8 @@ use std::{error::Error, fmt};
 
 #[cfg(not(feature = "std"))]
 use core::fmt;
+#[cfg(not(feature = "std"))]
+use export::core::String;
 
 /// Runtime error when a `build()` method is called and one or more required fields
 /// do not have a value.
@@ -33,5 +35,36 @@ impl Error for UninitializedFieldError {}
 impl From<&'static str> for UninitializedFieldError {
     fn from(field_name: &'static str) -> Self {
         Self::new(field_name)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct PostBuildError(String);
+
+impl PostBuildError {
+    /// Create a new `UnitializedFieldError` for the specified field name.
+    pub fn new(msg: String) -> Self {
+        PostBuildError(msg)
+    }
+
+    /// Get the name of the first-declared field that wasn't initialized
+    #[allow(dead_code)]
+    pub fn get_msg(self) -> String {
+        self.0
+    }
+}
+
+impl fmt::Display for PostBuildError {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "post build error: {}", self.0)
+    }
+}
+
+#[cfg(feature = "std")]
+impl Error for PostBuildError {}
+
+impl From<&'static str> for PostBuildError {
+    fn from(msg: &'static str) -> Self {
+        Self::new(msg.to_string())
     }
 }

--- a/derive_builder/src/lib.rs
+++ b/derive_builder/src/lib.rs
@@ -722,7 +722,7 @@ mod error;
 pub use derive_builder_macro::Builder;
 
 #[doc(inline)]
-pub use error::UninitializedFieldError;
+pub use error::{PostBuildError, UninitializedFieldError};
 
 #[doc(hidden)]
 pub mod export {

--- a/derive_builder/src/lib.rs
+++ b/derive_builder/src/lib.rs
@@ -500,6 +500,98 @@
 //! Note:
 //! * Default values are applied _after_ validation, and will therefore not be validated!
 //!
+//! ## post build operation
+//!
+//! some times, one or more fields of your struct need to be built according to other field's values.
+//!
+//!May be you have a layout which needs tpo know all other field's values to be built, or that you have some field that needs to be calculated only once for the struct
+//! and you don't want to recalculate it every time one of the fields are set in the builder.
+//!
+//! There are several situations in which a post build event might be useful.
+//!
+//! 1. You might have a field which needs to be calculated when the struct is built, but deppends on several other field values to calculate.
+//! 2. You might want to trigger an event whenever a new struct of a given type is built, so that other components of your application can react.
+//! 3. You might want to perform a complete validation which needs to know values of all fields to be performed.
+//!
+//!
+//! The classical ways to solve this problem would be:
+//!
+//! 1. call a method wich accepts &mut self in the target struct as soon as it is built. This method would make validations, trigger events, calculate fields.
+//! The main issue with this strategy is one can easily forget to call the post build method or function, and even if they don't, this function is effectively finishing to build the struct, so it shouldn't be decoupled from the building process at all. This post build function or  method also shouldn't be part of the public api.
+//!
+//! 2. Customize the setters of all fields affecting the field to be calculated and update it accordingly.
+//! The main issue with this strategy is that This would make room for repeated code, might run an expensive calculation on all calls to affected setters and would couple the set of the calculated field with the setters of all the affected fields, all things we want to avoid.
+//!
+//!
+//! The post_build parameter of #[derive(builder(build_fn))] allows you to provide a function or a method which gets called by the build() method of the builder struct as soon as the target struct is built.
+//!
+//! this solves the proposed problem, creates great ergonomy and decouples the set of the calculated field and all other side effects you might want to add with the setters of other fields
+//!
+//! In order to use post_build functionality, you can declare #[builder(build_fn(post_build = "path::to::fn"))] to specify a post build function which will be called as soon as the target struct is built, still inside the builder function. The path does not need to be fully-qualified, and will consider use statements made at module level. It must be accessible from the scope where the target struct is declared.
+//!
+//! The provided function must have the signature (&mut Foo) -> Result<_, String>; the Ok variant is not used by the build method.
+//!
+//! ```rust
+//! use derive_builder::{PostBuildError, UninitializedFieldError};
+//!
+//! #[macro_use]
+//! extern crate derive_builder;
+//!
+//! #[derive(Debug, Clone, Builder, PartialEq, Eq)]
+//! #[builder(build_fn(post_build = "LoremBuilder::post_build"))]
+//! pub struct Lorem {
+//! /// a number
+//!     number: i32,
+//!
+//!     /// big_number
+//!     /// this will be calculated by the post build function, so it should not (though mothing prevents it from) make a setter available.
+//!     /// It also should have a default value, either specified in the builder directive or delegated to the Default trait of the type
+//!     #[builder(setter(skip), default = "false")]
+//!     big_number: bool,
+//! }
+//!
+//! impl LoremBuilder {
+//!     /// performs post build operation
+//!     fn post_build(target: &mut Lorem) -> Result<(), String> {
+//!         // post build validation
+//!         if target.number <= 0 {
+//!             return Err("Number must be greater than 0".to_string());
+//!         }
+//!         // remember that we didn't set the big_number field. We deppend on the number field to decide if this instance has or hasn't a big number.
+//!         // This can only be safely known when the struct has just been built but nobody for sure yet used it
+//!         if target.number > 60 {
+//!             // initialize the big_number field
+//!             target.big_number = true;
+//!         }
+//!
+//!         Ok(())
+//!     }
+//! }
+//!
+//! fn main() {
+//!     // post build does not modify the big_number default field value
+//!     let x = LoremBuilder::default().number(20).build().unwrap();
+//!     assert_eq!(x.big_number, false);
+//!
+//!     // post build modifies the big_number field value
+//!     let x = LoremBuilder::default().number(80).build().unwrap();
+//!     assert_eq!(x.big_number, true);
+//!
+//!     // post build validation fails
+//!     let x = LoremBuilder::default().number(-1).build().unwrap_err();
+//!     let correct_variant = match x {
+//!         LoremBuilderError::UninitializedField(_) => {
+//!             panic!("Should get a post builder error, got a uninitialized field error instead")
+//!         }
+//!         LoremBuilderError::PostBuildError(e) => true,
+//!         LoremBuilderError::ValidationError(_) => {
+//!             panic!("Should get a post builder error, got a validation error instead")
+//!         }
+//!     };
+//!     assert!(correct_variant);
+//! }
+//! ```
+//!
 //! ## Additional Trait Derivations
 //!
 //! You can derive additional traits on the builder, including traits defined by other crates:
@@ -597,6 +689,8 @@
 //! pub enum LoremBuilderError { // where `LoremBuilder` is the name of the builder struct
 //!     /// Uninitialized field
 //!     UninitializedField(&'static str),
+//!     /// post build error
+//!     PostBuildError(String),
 //!     /// Custom validation error
 //!     ValidationError(String),
 //! }
@@ -613,10 +707,10 @@
 //!
 //! Alternatively, you can specify your own error type:
 //! ```rust
-//! # #[macro_use]
-//! # extern crate derive_builder;
-//! # use derive_builder::UninitializedFieldError;
-//! #
+//! #[macro_use]
+//! extern crate derive_builder;
+//! use derive_builder::UninitializedFieldError;
+//!
 //! #[derive(Builder, Debug, PartialEq)]
 //! #[builder(build_fn(error = "OurLoremError"))]
 //! struct Lorem {
@@ -635,13 +729,72 @@
 //! # }
 //! ```
 //!
+//! if you are using post build functionality, you need to provide a conversion  from PostBuildError for your custom error type
+//!
+//! ```rust
+//! use derive_builder::{ PostBuildError, UninitializedFieldError };
+//!
+//! #[macro_use]
+//! extern crate derive_builder;
+//!
+//! #[derive(Builder, Debug, PartialEq)]
+//! #[builder(build_fn(
+//!     post_build = "LoremCustomErrorBuilder::post_build",
+//!     error = "OurLoremError"
+//! ))]
+//! struct LoremCustomError {
+//!     /// a number
+//!     number: i32,
+//!
+//!     /// big_number
+//!     #[builder(setter(skip), default = "false")]
+//!     big_number: bool,
+//! }
+//!
+//! impl LoremCustomErrorBuilder {
+//!     /// performs post build operation
+//!     fn post_build(target: &mut LoremCustomError) -> Result<(), String> {
+//!         if target.number <= 0 {
+//!             return Err("Number must be greater than 0".to_string());
+//!         }
+//!         if target.number > 60 {
+//!             target.big_number = true;
+//!         }
+//!
+//!         Ok(())
+//!     }
+//! }
+//!
+//! #[derive(Debug)]
+//! struct OurLoremError(String);
+//!
+//! impl From<UninitializedFieldError> for OurLoremError {
+//!     fn from(ufe: UninitializedFieldError) -> OurLoremError {
+//!         OurLoremError(ufe.to_string())
+//!     }
+//! }
+//!
+//! impl From<PostBuildError> for OurLoremError {
+//!     fn from(pbe: PostBuildError) -> OurLoremError {
+//!         OurLoremError(format!("Custom build error: {}", pbe.get_msg()))
+//!     }
+//! }
+//!
+//! fn main() {
+//!     // should get a custom error instance when using post build with a custom error
+//!     let x = LoremCustomErrorBuilder::default().number(-1).build();
+//!
+//!     assert!(x.is_err());
+//! }
+//! ```
+//!
 //! # Completely custom fields in the builder
 //!
 //! Instead of having an `Option`, you can have whatever type you like:
 //!
 //! ```rust
-//! # #[macro_use]
-//! # extern crate derive_builder;
+//! #[macro_use]
+//! extern crate derive_builder;
 //! #[derive(Debug, PartialEq, Default, Builder, Clone)]
 //! #[builder(derive(Debug, PartialEq))]
 //! struct Lorem {

--- a/derive_builder/tests/compile-fail/custom_error_no_post_build.rs
+++ b/derive_builder/tests/compile-fail/custom_error_no_post_build.rs
@@ -1,0 +1,57 @@
+#[macro_use]
+extern crate derive_builder;
+
+fn validate_age(age: usize) -> Result<(), Error> {
+    if age > 200 {
+        Err(Error::UnrealisticAge(age))
+    } else {
+        Ok(())
+    }
+}
+
+fn check_person(builder: &PersonBuilder) -> Result<(), Error> {
+    if let Some(age) = builder.age {
+        validate_age(age)
+    } else {
+        Ok(())
+    }
+}
+
+#[derive(Builder)]
+#[builder(build_fn(
+    validate = "check_person",
+    post_build = "Self::post_build",
+    error = "Error"
+))]
+struct Person {
+    name: String,
+    age: i32,
+    #[builder(setter(skip), default = "false")]
+    person_exists: bool,
+}
+
+impl PersonBuilder {
+    fn post_build(target: &mut Person) -> Result<(), String> {
+        if person.age < 0 {
+            return Err("this person does not exist".to_string());
+        }
+        Ok(())
+    }
+}
+
+// note: This error does not implement a conversion from PostBuildError, required if a post build operation is configured, which is a
+// compile-blocking mistake.
+#[derive(Debug)]
+enum Error {
+    /// A required field is not filled out.
+    MissingData(String),
+    UnrealisticAge(usize),
+}
+
+impl From<UninitializedFieldError> for Error {
+    fn from(ufe: UninitializedFieldError) -> OurLoremError {
+        Error::MissingData(ufe.to_string())
+    }
+}
+
+fn main() {}

--- a/derive_builder/tests/post_build.rs
+++ b/derive_builder/tests/post_build.rs
@@ -1,0 +1,99 @@
+use derive_builder::{PostBuildError, UninitializedFieldError};
+
+#[macro_use]
+extern crate derive_builder;
+
+#[derive(Debug, Clone, Builder, PartialEq, Eq)]
+#[builder(build_fn(post_build = "LoremBuilder::post_build"))]
+pub struct Lorem {
+    /// a number
+    number: i32,
+
+    /// big_number
+    #[builder(setter(skip), default = "false")]
+    big_number: bool,
+}
+
+impl LoremBuilder {
+    /// performs post build operation
+    fn post_build(target: &mut Lorem) -> Result<(), String> {
+        if target.number <= 0 {
+            return Err("Number must be greater than 0".to_string());
+        }
+        if target.number > 60 {
+            target.big_number = true;
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Builder, Debug, PartialEq)]
+#[builder(build_fn(
+    post_build = "LoremCustomErrorBuilder::post_build",
+    error = "OurLoremError"
+))]
+struct LoremCustomError {
+    /// a number
+    number: i32,
+
+    /// big_number
+    #[builder(setter(skip), default = "false")]
+    big_number: bool,
+}
+
+impl LoremCustomErrorBuilder {
+    /// performs post build operation
+    fn post_build(target: &mut LoremCustomError) -> Result<(), String> {
+        if target.number <= 0 {
+            return Err("Number must be greater than 0".to_string());
+        }
+        if target.number > 60 {
+            target.big_number = true;
+        }
+
+        Ok(())
+    }
+}
+
+#[derive(Debug)]
+struct OurLoremError(String);
+
+impl From<UninitializedFieldError> for OurLoremError {
+    fn from(ufe: UninitializedFieldError) -> OurLoremError {
+        OurLoremError(ufe.to_string())
+    }
+}
+
+impl From<PostBuildError> for OurLoremError {
+    fn from(pbe: PostBuildError) -> OurLoremError {
+        OurLoremError(format!("Custom build error: {}", pbe.get_msg()))
+    }
+}
+
+#[test]
+#[should_panic(expected = "Number must be greater than 0")]
+fn post_build_generates_error() {
+    LoremBuilder::default().number(-1).build().unwrap();
+}
+
+#[test]
+fn post_build_runs_without_modifying_built_struct() {
+    let x = LoremBuilder::default().number(20).build().unwrap();
+    assert_eq!(x.big_number, false);
+}
+
+#[test]
+fn post_build_runs_and_modifies_built_struct() {
+    let x = LoremBuilder::default().number(80).build().unwrap();
+    assert_eq!(x.big_number, true);
+}
+
+#[test]
+#[should_panic(expected = "Custom build error: Number must be greater than 0")]
+fn post_build_generates_error_using_custom_error() {
+    LoremCustomErrorBuilder::default()
+        .number(-1)
+        .build()
+        .unwrap();
+}

--- a/derive_builder_core/src/builder.rs
+++ b/derive_builder_core/src/builder.rs
@@ -235,6 +235,8 @@ impl<'a> ToTokens for Builder<'a> {
                     #builder_vis enum #builder_error_ident {
                         /// Uninitialized field
                         UninitializedField(&'static str),
+                        /// post build operation error
+                        PostBuildError(::derive_builder::export::core::string::String),                        
                         /// Custom validation error
                         ValidationError(::derive_builder::export::core::string::String),
                     }
@@ -242,6 +244,12 @@ impl<'a> ToTokens for Builder<'a> {
                     impl ::derive_builder::export::core::convert::From<::derive_builder::UninitializedFieldError> for #builder_error_ident {
                         fn from(s: ::derive_builder::UninitializedFieldError) -> Self {
                             Self::UninitializedField(s.field_name())
+                        }
+                    }
+
+                    impl ::derive_builder::export::core::convert::From<::derive_builder::PostBuildError> for #builder_error_ident {
+                        fn from(s: ::derive_builder::PostBuildError) -> Self {
+                            Self::PostBuildError(s.get_msg())
                         }
                     }
 
@@ -255,6 +263,7 @@ impl<'a> ToTokens for Builder<'a> {
                         fn fmt(&self, f: &mut ::derive_builder::export::core::fmt::Formatter) -> ::derive_builder::export::core::fmt::Result {
                             match self {
                                 Self::UninitializedField(ref field) => write!(f, "`{}` must be initialized", field),
+                                Self::PostBuildError(ref error) => write!(f, "{}", error),
                                 Self::ValidationError(ref error) => write!(f, "{}", error),
                             }
                         }
@@ -371,6 +380,8 @@ mod tests {
             pub enum FooBuilderError {
                 /// Uninitialized field
                 UninitializedField(&'static str),
+                /// post build operation error
+                PostBuildError(::derive_builder::export::core::string::String),
                 /// Custom validation error
                 ValidationError(::derive_builder::export::core::string::String),
             }
@@ -378,6 +389,12 @@ mod tests {
             impl ::derive_builder::export::core::convert::From<::derive_builder::UninitializedFieldError> for FooBuilderError {
                 fn from(s: ::derive_builder::UninitializedFieldError) -> Self {
                     Self::UninitializedField(s.field_name())
+                }
+            }
+
+            impl ::derive_builder::export::core::convert::From<::derive_builder::PostBuildError> for FooBuilderError {
+                fn from(s: ::derive_builder::PostBuildError) -> Self {
+                    Self::PostBuildError(s.get_msg())
                 }
             }
 
@@ -391,6 +408,7 @@ mod tests {
                 fn fmt(&self, f: &mut ::derive_builder::export::core::fmt::Formatter) -> ::derive_builder::export::core::fmt::Result {
                     match self {
                         Self::UninitializedField(ref field) => write!(f, "`{}` must be initialized", field),
+                        Self::PostBuildError(ref error) => write!(f, "{}", error),
                         Self::ValidationError(ref error) => write!(f, "{}", error),
                     }
                 }

--- a/derive_builder_core/src/macro_options/darling_opts.rs
+++ b/derive_builder_core/src/macro_options/darling_opts.rs
@@ -78,6 +78,7 @@ pub struct BuildFn {
     skip: bool,
     name: Ident,
     validate: Option<Path>,
+    post_build: Option<Path>,
     public: Flag,
     private: Flag,
     vis: Option<syn::Visibility>,
@@ -103,6 +104,7 @@ impl Default for BuildFn {
             skip: false,
             name: Ident::new("build", Span::call_site()),
             validate: None,
+            post_build: None,
             public: Default::default(),
             private: Default::default(),
             vis: None,
@@ -707,6 +709,7 @@ impl Options {
             doc_comment: None,
             default_struct: self.default.as_ref(),
             validate_fn: self.build_fn.validate.as_ref(),
+            post_build_fn: self.build_fn.post_build.as_ref(),
         }
     }
 }


### PR DESCRIPTION
In this pr, we suggest a new feature, in form of the post_build attribute added to build_fn.

For functional details, please refer to #259 .

## Technical implementation

This PR implement following changes:

1. A post_build attribute is created as a valid attribute on build_fn attribute.
2. The builder function code is modified to:

    * Build the target struct and assign it to a variable called res. If a post build fn is provided, the variable is mutable, otherwise it is immutable.
    * If a post_build fn is provided, call it passing the &mut reference to the target struct.
    * Convert errors from the post build function to a instance of the PostBuildError enumeration
    * If post_build fn succeeds *** or if no post_build fn is provided, return ok(res), where res is the variable holding the built struct.
3. A PostBuildError type is provided
4. Generate, for the auto generated error, a conversion from PostBuildError to the PostBuildError variant of the auto generated error.
5. Provide documentation and examples.

For reviewers: please bear in mind that this is my first contribution to a macro crate, so I might have missed something. I know for sure that the compile fail test is not right, as I had no way of running it *** I tried to look for instruction on the documentation but I did not find anything.

Special care was taken not to cause api breaking changes: only if one uses build_fn and custom errors together should them change the impls on the customer error to include a From<PostBuildError> implementation.
