### PR TITLE
Added builder() fn for the original struct which returns the actual builder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 /rls
 target
 Cargo.lock
+
+Makefile

--- a/derive_builder/examples/builder_function_for_the_struct.rs
+++ b/derive_builder/examples/builder_function_for_the_struct.rs
@@ -1,0 +1,24 @@
+// NOTE: generate fully expanded version with `cargo expand`.
+//
+//       cargo expand --example new_builder_function
+#![allow(dead_code)]
+
+#[macro_use]
+extern crate derive_builder;
+
+#[derive(Default, Builder, Debug)]
+#[builder(setter(into))]
+struct Channel {
+    token: i32,
+    special_info: i32,
+}
+
+fn main() {
+    // create a new `ChannelBuilder` using `builder` fn from the `Channel` struct
+    let ch = Channel::builder()
+        .special_info(42u8)
+        .token(19_124)
+        .build()
+        .unwrap();
+    println!("{:#?}", ch);
+}

--- a/derive_builder_core/src/builder.rs
+++ b/derive_builder_core/src/builder.rs
@@ -140,6 +140,48 @@ pub struct Builder<'a> {
     pub std: bool,
 }
 
+impl<'a> Builder<'a> {
+    #[doc = "
+        adding builder() fn on the original struct
+        ```rust
+        impl <original_struct> {
+         pub fn builder() -> <original_struct>Builder  {
+             <original_struct>Builder::default()
+         }
+        }
+        ```
+        Why ?
+        Because sometimes @alexzanderr likes to call the builder like this:
+        ```rust
+            let ch = Channel::builder()
+            .special_info(42u8)
+            .token(19_124)
+            .build()
+            .unwrap();
+        ```
+        Note the `Channel::builder()`, it generates the builder from the original struct.
+    "]
+    pub fn add_builder_fn_to_struct(&self, ast: &syn::DeriveInput) -> TokenStream {
+        // name of the original struct
+        let struct_name_ident = &ast.ident;
+        // name of the builder for the original struct
+        let builder_name_ident = &self.ident;
+
+        // rust source code
+        let expanded = quote! {
+            /// This returns a new builder for the original struct
+            impl #struct_name_ident {
+                pub fn builder() -> #builder_name_ident {
+                    #builder_name_ident::default()
+                }
+            }
+        };
+
+        // this token stream is appended in in `builder_for_struct`
+        TokenStream::from(expanded)
+    }
+}
+
 impl<'a> ToTokens for Builder<'a> {
     fn to_tokens(&self, tokens: &mut TokenStream) {
         if self.enabled {

--- a/derive_builder_core/src/lib.rs
+++ b/derive_builder_core/src/lib.rs
@@ -86,5 +86,8 @@ pub fn builder_for_struct(ast: syn::DeriveInput) -> proc_macro2::TokenStream {
 
     builder.push_build_fn(build_fn);
 
-    quote!(#builder)
+    // adds pub fn builder() to original struct
+    let extra_builder_fn = builder.add_builder_fn_to_struct(&ast);
+
+    quote!(#builder #extra_builder_fn)
 }


### PR DESCRIPTION
Hello.

Love your crate, thanks for the code.

Here I've added just a simple `builder()` function for the original struct, this is a small PR, but I really want that change in the original crate, to not make wrappers.

What I've changed in this PR:
- added `builder()` function for the original struct to create a new builder from the original struct. Example:
```rust
fn main() {
    // create a new `ChannelBuilder` using `builder` fn from the `Channel` struct
    let ch = Channel::builder()
        .special_info(42u8)
        .token(19_124)
        .build()
        .unwrap();
    println!("{:#?}", ch);
}
```
Note the `Channel::builder()`, wasn't before.
- added a rustfmt.toml, assuming that you didnt have formatting configured, mine is configured and I dont want to mess your code formatting
- added some things to ignore in .gitignore, cuz I'm using a Makefile and maybe you dont use
- added `builder_function_for_the_struct.rs` example to test the usage of the `builder()` fn

Additional notes:
- there is nothing to test, since its a simple wrapper function 


Thats it. I assuming that you won't like the code structure, it didnt follow your pattern, we'll see.
In the first place I tried to add the changes to the `to_tokens` function, but I realised that this function doesnt get `ast: syn::DeriveInput` as parameter and also `Builder` struct has no fields with `ast`, has everything except the name of the original struct. I really needed the name of the struct, the name of struct wasn't defined in the `to_tokens` function, so I made a separate method for `Builder` to call from the macro.

Anyway, I'm open to code suggestions if you dont like it.

Thanks.