### PR TITLE
Produce error for `default` with `field.type`

### DIFF
--- a/derive_builder/CHANGELOG.md
+++ b/derive_builder/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+- Produce error when `default` is used with `field(type = "...")` rather than silently ignoring `default` #269
+
 ## [0.11.2] - 2022-04-20
 - Allow restricted visibility using `vis = "..."` for builders, build methods, setters, and fields #247
 - Allow specifying the type of a builder field using `#[builder(field(type = "..."))]` #246

--- a/derive_builder/tests/compile-fail/builder_field_custom.rs
+++ b/derive_builder/tests/compile-fail/builder_field_custom.rs
@@ -3,8 +3,20 @@ extern crate derive_builder;
 
 #[derive(Debug, PartialEq, Default, Builder, Clone)]
 pub struct Lorem {
-    #[builder(default = "88", field(type = "usize", build = "self.ipsum + 42"))]
+    // `default` is incompatible with `field.build`
+    #[builder(
+        default = "1",
+        field(build = "self.ipsum.map(|v| v + 42).unwrap_or(100)")
+    )]
     ipsum: usize,
+
+    // `default` is incompatible with `field.type`, even without `field.build`
+    #[builder(default = "2", field(type = "usize"))]
+    sit: usize,
+
+    // Both errors can occur on the same field
+    #[builder(default = "3", field(type = "usize", build = "self.ipsum + 42"))]
+    amet: usize,
 }
 
 fn main() {}

--- a/derive_builder/tests/compile-fail/builder_field_custom.stderr
+++ b/derive_builder/tests/compile-fail/builder_field_custom.stderr
@@ -1,5 +1,23 @@
 error: #[builder(default)] and #[builder(field(build="..."))] cannot be used together
- --> tests/compile-fail/builder_field_custom.rs:6:25
+ --> tests/compile-fail/builder_field_custom.rs:8:19
   |
-6 |     #[builder(default = "88", field(type = "usize", build = "self.ipsum + 42"))]
-  |                         ^^^^
+8 |         default = "1",
+  |                   ^^^
+
+error: #[builder(default)] and #[builder(field(type="..."))] cannot be used together
+  --> tests/compile-fail/builder_field_custom.rs:14:25
+   |
+14 |     #[builder(default = "2", field(type = "usize"))]
+   |                         ^^^
+
+error: #[builder(default)] and #[builder(field(build="..."))] cannot be used together
+  --> tests/compile-fail/builder_field_custom.rs:18:25
+   |
+18 |     #[builder(default = "3", field(type = "usize", build = "self.ipsum + 42"))]
+   |                         ^^^
+
+error: #[builder(default)] and #[builder(field(type="..."))] cannot be used together
+  --> tests/compile-fail/builder_field_custom.rs:18:25
+   |
+18 |     #[builder(default = "3", field(type = "usize", build = "self.ipsum + 42"))]
+   |                         ^^^


### PR DESCRIPTION
If `field.type` is used without `field.build`, a Move conversion is used instead of the OptionOrDefault conversion. This means that the presence of `field.type` prevents a field-level `default` from doing anything. Standard practice in derive_builder is to produce an error when parameters are not going to be used.

Fixes #269