### PR TITLE
Don't hide the Builder macro in docs

### DIFF
--- a/derive_builder_macro/src/lib.rs
+++ b/derive_builder_macro/src/lib.rs
@@ -10,7 +10,9 @@ extern crate derive_builder_core;
 
 use proc_macro::TokenStream;
 
-#[doc(hidden)]
+/// Create a builder struct for the deriving struct.
+///
+/// See the `derive_builder` crate documentation for more details.
 #[proc_macro_derive(
     Builder,
     attributes(


### PR DESCRIPTION
I'm pretty sure this was originally done to emulate `serde`, but `serde` has traits that match the name of its derive macros so the hiding makes more sense there.