### PR TITLE
Update license field following SPDX 2.1 license expression standard

### DIFF
--- a/derive_builder/Cargo.toml
+++ b/derive_builder/Cargo.toml
@@ -10,7 +10,7 @@ description = "Rust macro to automatically implement the builder pattern for arb
 repository = "https://github.com/colin-kiegel/rust-derive-builder"
 documentation = "https://docs.rs/derive_builder/0.12.0"
 
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 categories = ["development-tools", "rust-patterns"]
 keywords = ["derive", "macro", "builder", "setter", "struct"]
 readme = "README.md"

--- a/derive_builder/tests/dummy-crate/Cargo.toml
+++ b/derive_builder/tests/dummy-crate/Cargo.toml
@@ -3,7 +3,7 @@ name = "derive_builder_dummy_crate"
 version = "0.1.0"
 authors = ["Colin Kiegel <kiegel@gmx.de>"]
 description = "This dummy crate serves as a playground to **manually** inspect things like generated documentation. It is **not** tested automatically."
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 publish = false
 
 [lib]

--- a/derive_builder_core/Cargo.toml
+++ b/derive_builder_core/Cargo.toml
@@ -10,7 +10,7 @@ description = "Internal helper library for the derive_builder crate."
 repository = "https://github.com/colin-kiegel/rust-derive-builder"
 documentation = "https://docs.rs/derive_builder_core"
 
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 readme = "README.md"
 
 [features]

--- a/derive_builder_macro/Cargo.toml
+++ b/derive_builder_macro/Cargo.toml
@@ -10,7 +10,7 @@ description = "Rust macro to automatically implement the builder pattern for arb
 repository = "https://github.com/colin-kiegel/rust-derive-builder"
 documentation = "https://docs.rs/derive_builder_macro/0.12.0"
 
-license = "MIT/Apache-2.0"
+license = "MIT OR Apache-2.0"
 categories = ["development-tools", "rust-patterns"]
 keywords = ["derive", "macro", "builder", "setter", "struct"]
 readme = "README.md"


### PR DESCRIPTION
The new recommendation is to follow the SPDX 2.1 standard. This allows automatic license verification software to work properly. Reference: https://doc.rust-lang.org/cargo/reference/manifest.html#the-license-and-license-file-fields