### PR TITLE
Allows prevention of `alloc` dependency through feature and disabling of `ValidationError(String)` variant.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,7 @@ jobs:
           - 1.56.0 # MSRV
         features:
           - ""
-          - --no-default-features
+          - --no-default-features --features alloc
           - --features clippy
 
     env:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,2 +1,2 @@
 [workspace]
-members = ["derive_builder", "derive_builder_macro", "derive_builder_core", "derive_builder_no_std_tests"]
+members = ["derive_builder", "derive_builder_macro", "derive_builder_core", "derive_builder_no_alloc_tests", "derive_builder_no_std_tests"]

--- a/derive_builder/CHANGELOG.md
+++ b/derive_builder/CHANGELOG.md
@@ -2,6 +2,10 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased] - 2023-12-21
+- Add `build_fn(validation_error = <bool>)` to disable generation of `ValidationError` within the builder's error so that `alloc::string` is avoided.
+- Add feature `alloc` for controlling linking of `alloc` crate during `no_std`. This way users can use `no_std` without providing a `global_allocator`.
+
 ## [Unreleased] - 2023-07-25
 - Make try-setters inherit `strip_option` from `setter` for `try_setter`. Using these settings together previously caused a compile error  #284
 

--- a/derive_builder/CHANGELOG.md
+++ b/derive_builder/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased] - 2023-12-21
-- Add `build_fn(validation_error = <bool>)` to disable generation of `ValidationError` within the builder's error so that `alloc::string` is avoided.
+- Add `build_fn(error(validation_error = <bool>))` to disable generation of `ValidationError` within the builder's error so that `alloc::string` is avoided.
 - Add feature `alloc` for controlling linking of `alloc` crate during `no_std`. This way users can use `no_std` without providing a `global_allocator`.
 
 ## [Unreleased] - 2023-07-25

--- a/derive_builder/Cargo.toml
+++ b/derive_builder/Cargo.toml
@@ -19,6 +19,7 @@ readme = "README.md"
 default = ["std"]
 std = []
 clippy = ["derive_builder_macro/clippy"]
+alloc = []
 
 [dependencies]
 derive_builder_macro = { version = "=0.12.0", path = "../derive_builder_macro" }

--- a/derive_builder/Cargo.toml
+++ b/derive_builder/Cargo.toml
@@ -17,9 +17,9 @@ readme = "README.md"
 
 [features]
 default = ["std"]
-std = []
+std = ["derive_builder_macro/lib_has_std"]
 clippy = ["derive_builder_macro/clippy"]
-alloc = []
+alloc = ["derive_builder_macro/alloc"]
 
 [dependencies]
 derive_builder_macro = { version = "=0.12.0", path = "../derive_builder_macro" }

--- a/derive_builder/README.md
+++ b/derive_builder/README.md
@@ -129,7 +129,8 @@ It's as simple as three steps:
 - **Custom build method error types**: You can use `#[builder(build_fn(error = "path::to::Error"))]` to have your builder return an error type of your choosing. By default, the macro will emit an error type alongside the builder.
 - **Builder derivations**: You can use `#[builder(derive(Trait1, Trait2, ...))]` to have the builder derive additonal traits. All builders derive `Default` and `Clone`, so you should not declare those in this attribute.
 - **Pass-through attributes**: Use `#[builder_struct_attr(...)]`, `#[builder_impl_attr(...)]`, `#[builder_field_attr(...)]`, and `#[builder_setter_attr(...)]` to declare attributes that will be added to the relevant part of the generated builder.
-- **no_std support**: Just add `#[builder(no_std)]` to your struct and add `extern crate alloc` to your crate.
+- **no_std support**: Just add `#[builder(no_std)]` to your struct, use feature `alloc`, and add `extern crate alloc` to your crate.
+- **No alloc no_std support**: Do not use `alloc` feature and then either add `#[builder(no_std, build_fn(validation_error = false))]` or `#[builder(no_std, build_fn(error = "path::to::Error"))]` to your struct.
 - **Renaming and re-export support**: Use `#[builder(crate = "...")]` to set the root for `derive_builder`. This is useful if you want to rename `derive_builder` in `Cargo.toml` or if your crate is re-exporting `derive_builder::Builder` and needs the generated code to not directly reference the `derive_builder` crate.
 
 For more information and examples please take a look at our [documentation][doc].

--- a/derive_builder/README.md
+++ b/derive_builder/README.md
@@ -130,7 +130,7 @@ It's as simple as three steps:
 - **Builder derivations**: You can use `#[builder(derive(Trait1, Trait2, ...))]` to have the builder derive additonal traits. All builders derive `Default` and `Clone`, so you should not declare those in this attribute.
 - **Pass-through attributes**: Use `#[builder_struct_attr(...)]`, `#[builder_impl_attr(...)]`, `#[builder_field_attr(...)]`, and `#[builder_setter_attr(...)]` to declare attributes that will be added to the relevant part of the generated builder.
 - **no_std support**: Just add `#[builder(no_std)]` to your struct, use feature `alloc`, and add `extern crate alloc` to your crate.
-- **No alloc no_std support**: Do not use `alloc` feature and then either add `#[builder(no_std, build_fn(validation_error = false))]` or `#[builder(no_std, build_fn(error = "path::to::Error"))]` to your struct.
+- **No alloc no_std support**: Do not use `alloc` feature and then either add `#[builder(no_std, build_fn(error(validation_error = false)))]` or `#[builder(no_std, build_fn(error = "path::to::Error"))]` to your struct.
 - **Renaming and re-export support**: Use `#[builder(crate = "...")]` to set the root for `derive_builder`. This is useful if you want to rename `derive_builder` in `Cargo.toml` or if your crate is re-exporting `derive_builder::Builder` and needs the generated code to not directly reference the `derive_builder` crate.
 
 For more information and examples please take a look at our [documentation][doc].

--- a/derive_builder/src/lib.rs
+++ b/derive_builder/src/lib.rs
@@ -712,7 +712,7 @@
 #![deny(warnings)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
-#[cfg(not(feature = "std"))]
+#[cfg(feature = "alloc")]
 extern crate alloc;
 
 extern crate derive_builder_macro;
@@ -727,7 +727,7 @@ pub use error::UninitializedFieldError;
 #[doc(hidden)]
 pub mod export {
     pub mod core {
-        #[cfg(not(feature = "std"))]
+        #[cfg(feature = "alloc")]
         pub use alloc::string;
         #[cfg(not(feature = "std"))]
         pub use core::*;

--- a/derive_builder/tests/compile-fail/build_fn_error.rs
+++ b/derive_builder/tests/compile-fail/build_fn_error.rs
@@ -1,0 +1,27 @@
+use derive_builder::Builder;
+
+#[derive(Builder)]
+#[builder(build_fn(error(validation_error = false, path = "hello")))]
+struct Fee {
+    hi: u32,
+}
+
+#[derive(Builder)]
+#[builder(build_fn(error(validation_error = false), validate = "hello"))]
+struct Foo {
+    hi: u32,
+}
+
+#[derive(Builder)]
+#[builder(build_fn(error(path = "hello")))]
+struct Fii {
+    hi: u32,
+}
+
+#[derive(Builder)]
+#[builder(build_fn(error()))]
+struct Fum {
+    hi: u32,
+}
+
+fn main() {}

--- a/derive_builder/tests/compile-fail/build_fn_error.stderr
+++ b/derive_builder/tests/compile-fail/build_fn_error.stderr
@@ -1,0 +1,23 @@
+error: Too many items: Expected no more than 1
+ --> tests/compile-fail/build_fn_error.rs:4:20
+  |
+4 | #[builder(build_fn(error(validation_error = false, path = "hello")))]
+  |                    ^^^^^
+
+error: Cannot set `error(validation_error = false)` when using `validate`
+  --> tests/compile-fail/build_fn_error.rs:10:26
+   |
+10 | #[builder(build_fn(error(validation_error = false), validate = "hello"))]
+   |                          ^^^^^^^^^^^^^^^^
+
+error: Unknown field: `path`
+  --> tests/compile-fail/build_fn_error.rs:16:26
+   |
+16 | #[builder(build_fn(error(path = "hello")))]
+   |                          ^^^^
+
+error: Too few items: Expected at least 1
+  --> tests/compile-fail/build_fn_error.rs:22:20
+   |
+22 | #[builder(build_fn(error()))]
+   |                    ^^^^^

--- a/derive_builder/tests/compile-fail/build_fn_error.stderr
+++ b/derive_builder/tests/compile-fail/build_fn_error.stderr
@@ -1,8 +1,8 @@
-error: Too many items: Expected no more than 1
- --> tests/compile-fail/build_fn_error.rs:4:20
+error: Unknown field: `path`
+ --> tests/compile-fail/build_fn_error.rs:4:52
   |
 4 | #[builder(build_fn(error(validation_error = false, path = "hello")))]
-  |                    ^^^^^
+  |                                                    ^^^^
 
 error: Cannot set `error(validation_error = false)` when using `validate`
   --> tests/compile-fail/build_fn_error.rs:10:26
@@ -16,7 +16,15 @@ error: Unknown field: `path`
 16 | #[builder(build_fn(error(path = "hello")))]
    |                          ^^^^
 
-error: Too few items: Expected at least 1
+error: Missing field `validation_error` at build_fn/error
+  --> tests/compile-fail/build_fn_error.rs:15:10
+   |
+15 | #[derive(Builder)]
+   |          ^^^^^^^
+   |
+   = note: this error originates in the derive macro `Builder` (in Nightly builds, run with -Z macro-backtrace for more info)
+
+error: Missing field `validation_error`
   --> tests/compile-fail/build_fn_error.rs:22:20
    |
 22 | #[builder(build_fn(error()))]

--- a/derive_builder/tests/compile-fail/build_fn_error.stderr
+++ b/derive_builder/tests/compile-fail/build_fn_error.stderr
@@ -5,10 +5,10 @@ error: Unknown field: `path`
   |                                                    ^^^^
 
 error: Cannot set `error(validation_error = false)` when using `validate`
-  --> tests/compile-fail/build_fn_error.rs:10:26
+  --> tests/compile-fail/build_fn_error.rs:10:45
    |
 10 | #[builder(build_fn(error(validation_error = false), validate = "hello"))]
-   |                          ^^^^^^^^^^^^^^^^
+   |                                             ^^^^^
 
 error: Unknown field: `path`
   --> tests/compile-fail/build_fn_error.rs:16:26

--- a/derive_builder_core/Cargo.toml
+++ b/derive_builder_core/Cargo.toml
@@ -14,7 +14,9 @@ license = "MIT OR Apache-2.0"
 readme = "README.md"
 
 [features]
+alloc = []
 clippy = []
+lib_has_std = []
 
 [dependencies]
 darling = "0.14.0"

--- a/derive_builder_core/src/builder.rs
+++ b/derive_builder_core/src/builder.rs
@@ -132,8 +132,8 @@ pub struct Builder<'a> {
     /// Whether to include `ValidationError` in the generated enum. Necessary to avoid dependency
     /// on `alloc::string`.
     ///
-    /// This would be `false` when `build_fn.validation_error == false`. This is ignored when
-    /// `generate_error` is `false`.
+    /// This would be `false` when `build_fn.error.as_validation_error() == Some((false, _))`. This
+    /// has no effect when `generate_error` is `false`.
     pub generate_validation_error: bool,
     /// Whether this builder must derive `Clone`.
     ///

--- a/derive_builder_core/src/builder.rs
+++ b/derive_builder_core/src/builder.rs
@@ -12,6 +12,11 @@ use BuilderPattern;
 use DeprecationNotes;
 use Setter;
 
+const ALLOC_NOT_ENABLED_ERROR: &str = r#"`alloc` is disabled within 'derive_builder', consider one of the following:
+* enable feature `alloc` on 'dervie_builder' if a `global_allocator` is present
+* use a custom error `#[builder(build_fn(error = "path::to::Error"))]
+* disable the validation error `#[builder(build_fn(error(validation_error = false)))]"#;
+
 /// Builder, implementing `quote::ToTokens`.
 ///
 /// # Examples
@@ -135,6 +140,8 @@ pub struct Builder<'a> {
     /// This would be `false` when `build_fn.error.as_validation_error() == Some((false, _))`. This
     /// has no effect when `generate_error` is `false`.
     pub generate_validation_error: bool,
+    /// Indicator of `cfg!(not(any(feature = "alloc", feature = "std")))`, as a field for tests
+    pub no_alloc: bool,
     /// Whether this builder must derive `Clone`.
     ///
     /// This is true even for a builder using the `owned` pattern if there is a field whose setter
@@ -233,7 +240,10 @@ impl<'a> ToTokens for Builder<'a> {
                 ));
             }
 
-            if self.generate_error {
+            if self.no_alloc && self.generate_error && self.generate_validation_error {
+                let err = syn::Error::new_spanned(&self.ident, ALLOC_NOT_ENABLED_ERROR);
+                tokens.append_all(err.to_compile_error());
+            } else if self.generate_error {
                 let builder_error_ident = format_ident!("{}Error", builder_ident);
                 let builder_error_doc = format!("Error type for {}", builder_ident);
 
@@ -385,6 +395,7 @@ macro_rules! default_builder {
             functions: vec![quote!(fn bar() -> { unimplemented!() })],
             generate_error: true,
             generate_validation_error: true,
+            no_alloc: false,
             must_derive_clone: true,
             doc_comment: None,
             deprecation_notes: DeprecationNotes::default(),
@@ -399,6 +410,43 @@ mod tests {
     use super::*;
     use proc_macro2::TokenStream;
     use syn::Ident;
+
+    fn add_simple_foo_builder(result: &mut TokenStream) {
+        #[cfg(not(feature = "clippy"))]
+        result.append_all(quote!(#[allow(clippy::all)]));
+
+        result.append_all(quote!(
+            #[derive(Clone)]
+            pub struct FooBuilder {
+                foo: u32,
+            }
+        ));
+
+        #[cfg(not(feature = "clippy"))]
+        result.append_all(quote!(#[allow(clippy::all)]));
+
+        result.append_all(quote!(
+            #[allow(dead_code)]
+            impl FooBuilder {
+                fn bar () -> {
+                    unimplemented!()
+                }
+
+                /// Create an empty builder, with all fields set to `None` or `PhantomData`.
+                fn create_empty() -> Self {
+                    Self {
+                        foo: ::db::export::core::default::Default::default(),
+                    }
+                }
+            }
+
+            impl ::db::export::core::default::Default for FooBuilder {
+                fn default() -> Self {
+                    Self::create_empty()
+                }
+            }
+        ));
+    }
 
     fn add_generated_error(result: &mut TokenStream) {
         result.append_all(quote!(
@@ -446,40 +494,7 @@ mod tests {
             {
                 let mut result = quote!();
 
-                #[cfg(not(feature = "clippy"))]
-                result.append_all(quote!(#[allow(clippy::all)]));
-
-                result.append_all(quote!(
-                    #[derive(Clone)]
-                    pub struct FooBuilder {
-                        foo: u32,
-                    }
-                ));
-
-                #[cfg(not(feature = "clippy"))]
-                result.append_all(quote!(#[allow(clippy::all)]));
-
-                result.append_all(quote!(
-                    #[allow(dead_code)]
-                    impl FooBuilder {
-                        fn bar () -> {
-                            unimplemented!()
-                        }
-
-                        /// Create an empty builder, with all fields set to `None` or `PhantomData`.
-                        fn create_empty() -> Self {
-                            Self {
-                                foo: ::db::export::core::default::Default::default(),
-                            }
-                        }
-                    }
-
-                    impl ::db::export::core::default::Default for FooBuilder {
-                        fn default() -> Self {
-                            Self::create_empty()
-                        }
-                    }
-                ));
+                add_simple_foo_builder(&mut result);
 
                 add_generated_error(&mut result);
 
@@ -797,40 +812,7 @@ mod tests {
             {
                 let mut result = quote!();
 
-                #[cfg(not(feature = "clippy"))]
-                result.append_all(quote!(#[allow(clippy::all)]));
-
-                result.append_all(quote!(
-                    #[derive(Clone)]
-                    pub struct FooBuilder {
-                        foo: u32,
-                    }
-                ));
-
-                #[cfg(not(feature = "clippy"))]
-                result.append_all(quote!(#[allow(clippy::all)]));
-
-                result.append_all(quote!(
-                    #[allow(dead_code)]
-                    impl FooBuilder {
-                        fn bar () -> {
-                            unimplemented!()
-                        }
-
-                        /// Create an empty builder, with all fields set to `None` or `PhantomData`.
-                        fn create_empty() -> Self {
-                            Self {
-                                foo: ::db::export::core::default::Default::default(),
-                            }
-                        }
-                    }
-
-                    impl ::db::export::core::default::Default for FooBuilder {
-                        fn default() -> Self {
-                            Self::create_empty()
-                        }
-                    }
-                ));
+                add_simple_foo_builder(&mut result);
 
                 result.append_all(quote!(
                     #[doc="Error type for FooBuilder"]
@@ -857,6 +839,26 @@ mod tests {
 
                     impl std::error::Error for FooBuilderError {}
                 ));
+
+                result
+            }
+                .to_string()
+        );
+    }
+
+    #[test]
+    fn no_alloc_bug_using_string() {
+        let mut builder = default_builder!();
+        builder.no_alloc = true;
+
+        assert_eq!(
+            quote!(#builder).to_string(),
+            {
+                let mut result = quote!();
+
+                add_simple_foo_builder(&mut result);
+
+                result.append_all(quote!(compile_error! { #ALLOC_NOT_ENABLED_ERROR }));
 
                 result
             }

--- a/derive_builder_core/src/builder.rs
+++ b/derive_builder_core/src/builder.rs
@@ -237,26 +237,32 @@ impl<'a> ToTokens for Builder<'a> {
                 let builder_error_ident = format_ident!("{}Error", builder_ident);
                 let builder_error_doc = format!("Error type for {}", builder_ident);
 
-                let validation_error = self
-                    .generate_validation_error
-                    .then_some(quote!(
+                let validation_error = if self.generate_validation_error {
+                    quote!(
                         /// Custom validation error
                         ValidationError(#crate_root::export::core::string::String),
-                    ))
-                    .unwrap_or_default();
-                let validation_from = self.generate_validation_error.then_some(quote!(
-                    impl #crate_root::export::core::convert::From<#crate_root::export::core::string::String> for #builder_error_ident {
-                        fn from(s: #crate_root::export::core::string::String) -> Self {
-                            Self::ValidationError(s)
+                    )
+                } else {
+                    TokenStream::new()
+                };
+                let validation_from = if self.generate_validation_error {
+                    quote!(
+                        impl #crate_root::export::core::convert::From<#crate_root::export::core::string::String> for #builder_error_ident {
+                            fn from(s: #crate_root::export::core::string::String) -> Self {
+                                Self::ValidationError(s)
+                            }
                         }
-                    }
-                )).unwrap_or_default();
-                let validation_display = self
-                    .generate_validation_error
-                    .then_some(quote!(
+                    )
+                } else {
+                    TokenStream::new()
+                };
+                let validation_display = if self.generate_validation_error {
+                    quote!(
                         Self::ValidationError(ref error) => write!(f, "{}", error),
-                    ))
-                    .unwrap_or_default();
+                    )
+                } else {
+                    TokenStream::new()
+                };
 
                 tokens.append_all(quote!(
                     #[doc=#builder_error_doc]

--- a/derive_builder_core/src/macro_options/darling_opts.rs
+++ b/derive_builder_core/src/macro_options/darling_opts.rs
@@ -803,6 +803,7 @@ impl Options {
                 .as_ref()
                 .and_then(BuildFnError::as_validation_error)
                 .map_or(true, |(b, _)| b),
+            no_alloc: cfg!(not(any(feature = "alloc", feature = "lib_has_std"))),
             must_derive_clone: self.requires_clone(),
             doc_comment: None,
             deprecation_notes: Default::default(),

--- a/derive_builder_core/src/macro_options/darling_opts.rs
+++ b/derive_builder_core/src/macro_options/darling_opts.rs
@@ -69,6 +69,65 @@ fn no_visibility_conflict<T: Visibility>(v: &T) -> darling::Result<()> {
     }
 }
 
+#[derive(Debug, Clone)]
+enum BuildFnError {
+    Path(Path),
+    ValidationError(bool, Span),
+}
+
+impl BuildFnError {
+    fn as_path(&self) -> Option<&Path> {
+        match self {
+            BuildFnError::Path(p) => Some(p),
+            BuildFnError::ValidationError(_, _) => None,
+        }
+    }
+
+    fn as_validation_error(&self) -> Option<(bool, &Span)> {
+        match self {
+            BuildFnError::ValidationError(b, p) => Some((*b, p)),
+            BuildFnError::Path(_) => None,
+        }
+    }
+}
+
+impl FromMeta for BuildFnError {
+    fn from_list(items: &[syn::NestedMeta]) -> darling::Result<Self> {
+        let item = match items {
+            [] => Err(Error::too_few_items(1)),
+            [item] => Ok(item),
+            _ => Err(Error::too_many_items(1)),
+        }?;
+        let nested = match &item {
+            syn::NestedMeta::Meta(nested) => Ok(nested),
+            syn::NestedMeta::Lit(_) => Err(Error::unsupported_format("literal")),
+        }?;
+        match darling::util::path_to_string(nested.path()).as_ref() {
+            "validation_error" => {
+                let span = nested.span();
+                let boolean = FromMeta::from_meta(nested).map_err(|e| e.at("validation_error"))?;
+                Ok(BuildFnError::ValidationError(boolean, span))
+            }
+            other => {
+                Err(Error::unknown_field_with_alts(other, &["validation_error"]).with_span(nested))
+            }
+        }
+    }
+
+    fn from_value(value: &syn::Lit) -> darling::Result<Self> {
+        if let syn::Lit::Str(s) = value {
+            let contents: Path = s.parse()?;
+            if contents.segments.is_empty() {
+                Err(Error::unknown_value("").with_span(s))
+            } else {
+                Ok(Self::Path(contents))
+            }
+        } else {
+            Err(Error::unexpected_lit_type(value))
+        }
+    }
+}
+
 /// Options for the `build_fn` property in struct-level builder options.
 /// There is no inheritance for these settings from struct-level to field-level,
 /// so we don't bother using `Option` for values in this struct.
@@ -81,12 +140,21 @@ pub struct BuildFn {
     public: Flag,
     private: Flag,
     vis: Option<syn::Visibility>,
-    /// The path to an existing error type that the build method should return.
+    /// Either the path to an existing error type that the build method should return or a meta
+    /// list of options to modify the generated error.
     ///
-    /// Setting this will prevent `derive_builder` from generating an error type for the build
-    /// method.
+    /// Setting this to a path will prevent `derive_builder` from generating an error type for the
+    /// build method.
     ///
-    /// # Type Bounds
+    /// This options supports to formats: path `error = "path::to::Error"` and meta list
+    /// `error(<options>)`. Supported mata list options are the following:
+    ///
+    /// * `validation_error = bool` - Whether to generate `ValidationError(String)` as a variant
+    ///   of the build error type. Setting this to `false` will prevent `derive_builder` from
+    ///   using the `validate` function but this also means it does not generate any usage of the
+    ///  `alloc` crate (useful when disabling the `alloc` feature in `no_std`).
+    ///
+    /// # Type Bounds for Custom Error
     /// This type's bounds depend on other settings of the builder.
     ///
     /// * If uninitialized fields cause `build()` to fail, then this type
@@ -94,25 +162,21 @@ pub struct BuildFn {
     ///   when default values are provided for every field or at the struct level.
     /// * If `validate` is specified, then this type must provide a conversion from the specified
     ///   function's error type.
-    error: Option<Path>,
-    /// Whether to generate `ValidationError(String)` as a variant of the build error type.
-    ///
-    /// Setting this to `false` will prevent `derive_builder` from using the `validate` function
-    /// but this also means it does not generate any usage of the `alloc` crate (useful when
-    /// disabling the `alloc` feature in `no_std`).
-    validation_error: bool,
+    error: Option<BuildFnError>,
 }
 
 impl BuildFn {
     fn validation_needs_error(self) -> darling::Result<Self> {
-        if self.validate.is_some() && !self.validation_error {
-            Err(darling::Error::custom(
-                "Cannot set `validation_error = false` when using `validate`",
-            )
-            .with_span(&self.validate))
-        } else {
-            Ok(self)
+        let mut acc = Error::accumulator();
+        if let (true, Some(BuildFnError::ValidationError(false, s))) =
+            (self.validate.is_some(), &self.error)
+        {
+            acc.push(
+                Error::custom("Cannot set `error(validation_error = false)` when using `validate`")
+                    .with_span(s),
+            );
         }
+        acc.finish_with(self)
     }
 }
 
@@ -126,7 +190,6 @@ impl Default for BuildFn {
             private: Default::default(),
             vis: None,
             error: None,
-            validation_error: true,
         }
     }
 }
@@ -661,7 +724,7 @@ impl Options {
     }
 
     pub fn builder_error_ident(&self) -> Path {
-        if let Some(existing) = self.build_fn.error.as_ref() {
+        if let Some(BuildFnError::Path(existing)) = self.build_fn.error.as_ref() {
             existing.clone()
         } else if let Some(ref custom) = self.name {
             format_ident!("{}Error", custom).into()
@@ -728,8 +791,18 @@ impl Options {
             fields: Vec::with_capacity(self.field_count()),
             field_initializers: Vec::with_capacity(self.field_count()),
             functions: Vec::with_capacity(self.field_count()),
-            generate_error: self.build_fn.error.is_none(),
-            generate_validation_error: self.build_fn.validation_error,
+            generate_error: self
+                .build_fn
+                .error
+                .as_ref()
+                .and_then(BuildFnError::as_path)
+                .is_none(),
+            generate_validation_error: self
+                .build_fn
+                .error
+                .as_ref()
+                .and_then(BuildFnError::as_validation_error)
+                .map_or(true, |(b, _)| b),
             must_derive_clone: self.requires_clone(),
             doc_comment: None,
             deprecation_notes: Default::default(),
@@ -937,12 +1010,12 @@ impl<'a> FieldWithDefaults<'a> {
             default_value: self.field.default.as_ref(),
             use_default_struct: self.use_parent_default(),
             conversion: self.conversion(),
-            custom_error_type_span: self
-                .parent
-                .build_fn
-                .error
-                .as_ref()
-                .map(|err_ty| err_ty.span()),
+            custom_error_type_span: self.parent.build_fn.error.as_ref().and_then(|err_ty| {
+                match err_ty {
+                    BuildFnError::Path(p) => Some(p.span()),
+                    _ => None,
+                }
+            }),
         }
     }
 

--- a/derive_builder_macro/Cargo.toml
+++ b/derive_builder_macro/Cargo.toml
@@ -19,7 +19,9 @@ readme = "README.md"
 proc-macro = true
 
 [features]
+alloc = ["derive_builder_core/alloc"]
 clippy = ["derive_builder_core/clippy"]
+lib_has_std = ["derive_builder_core/lib_has_std"]
 
 [dependencies]
 syn = { version = "1.0.91", features = ["full", "extra-traits"] }

--- a/derive_builder_no_alloc_tests/Cargo.toml
+++ b/derive_builder_no_alloc_tests/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 publish = false
 
 [features]
+alloc = [] # To satify workflows which set `alloc`
 clippy = ["derive_builder/clippy"]
 
 [dependencies]

--- a/derive_builder_no_alloc_tests/Cargo.toml
+++ b/derive_builder_no_alloc_tests/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "derive_builder_no_alloc_tests"
+version = "0.1.0"
+authors = ["Micah Weston <micahsweston@gmail.com>"]
+edition = "2018"
+publish = false
+
+[features]
+clippy = ["derive_builder/clippy"]
+
+[dependencies]
+derive_builder = { path = "../derive_builder", default-features = false }

--- a/derive_builder_no_alloc_tests/src/lib.rs
+++ b/derive_builder_no_alloc_tests/src/lib.rs
@@ -1,0 +1,71 @@
+#![no_std]
+#![allow(unused, clippy::blacklisted_name)]
+
+use derive_builder::{self, Builder};
+
+#[derive(Debug, Eq, PartialEq)]
+pub struct FooError(&'static str);
+
+impl From<derive_builder::UninitializedFieldError> for FooError {
+    fn from(err: derive_builder::UninitializedFieldError) -> Self {
+        Self(err.field_name())
+    }
+}
+
+#[derive(Builder)]
+#[builder(no_std, build_fn(error = "FooError"))]
+pub struct Foo {
+    pub bar: i32,
+}
+
+#[derive(Builder)]
+#[builder(no_std, build_fn(validation_error = false))]
+pub struct Fee {
+    pub bar: i32,
+}
+
+pub fn build_foo_ok() -> Foo {
+    FooBuilder::default().bar(42).build().unwrap()
+}
+
+pub fn build_foo_err() -> Option<FooError> {
+    let foo = FooBuilder::default().build();
+    foo.err()
+}
+
+pub fn build_fee_ok() -> Foo {
+    FooBuilder::default().bar(42).build().unwrap()
+}
+
+pub fn build_fee_err() -> Option<FeeBuilderError> {
+    let fee = FeeBuilder::default().build();
+    fee.err()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_foo_builder_ok() {
+        assert_eq!(build_foo_ok().bar, 42);
+    }
+
+    #[test]
+    fn test_foo_builder_err() {
+        assert_eq!(build_foo_err(), Some(FooError("bar")));
+    }
+
+    #[test]
+    fn test_fee_builder_ok() {
+        assert_eq!(build_fee_ok().bar, 42);
+    }
+
+    #[test]
+    fn test_fee_builder_err() {
+        assert!(matches!(
+            build_fee_err(),
+            Some(FeeBuilderError::UninitializedField("bar"))
+        ));
+    }
+}

--- a/derive_builder_no_alloc_tests/src/lib.rs
+++ b/derive_builder_no_alloc_tests/src/lib.rs
@@ -19,7 +19,7 @@ pub struct Foo {
 }
 
 #[derive(Builder)]
-#[builder(no_std, build_fn(validation_error = false))]
+#[builder(no_std, build_fn(error(validation_error = false)))]
 pub struct Fee {
     pub bar: i32,
 }

--- a/derive_builder_no_std_tests/Cargo.toml
+++ b/derive_builder_no_std_tests/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2018"
 publish = false
 
 [features]
+alloc = [] # To satify workflows which set `alloc`
 clippy = ["derive_builder/clippy"]
 
 [dependencies]

--- a/derive_builder_no_std_tests/Cargo.toml
+++ b/derive_builder_no_std_tests/Cargo.toml
@@ -9,4 +9,4 @@ publish = false
 clippy = ["derive_builder/clippy"]
 
 [dependencies]
-derive_builder = { path = "../derive_builder", default-features = false }
+derive_builder = { path = "../derive_builder", default-features = false, features = ["alloc"] }


### PR DESCRIPTION
Currently, using `derive_builder` in `no_std` still forces the user to make a `global_allocator` since the crate links against `alloc`. This PR tries to avoid that in two aways.
* Create a new feature flag `alloc` that controls whether the `alloc` crate is used. This allows `no_std` user to opt into using allocation if they want it.
* New `build_fn` field, `validation_error: bool` that controls whether the generated error includes `ValidationError(String)`. This prevents usage of any `alloc` code but also limits the user from using the `validate` field.
  * The user can provide a custom `build_fn` `error` to avoid `alloc` code from being used.

This is to fix issue: https://github.com/colin-kiegel/rust-derive-builder/issues/303.