### PR TITLE
Accept field(ty = "...") to ease migration to syn 2.0

### DIFF
--- a/derive_builder/CHANGELOG.md
+++ b/derive_builder/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Unreleased
+- Accept `field(ty = "...")` as an alias for `field(type = "...")` in preparation for moving to syn 2.0, which doesn't allow the use of keywords as meta item paths.
+
 ## [0.13.0] - 2024-01-22
 - Bump MSRV to 1.56.0
 - Add `build_fn(error(validation_error = <bool>))` to disable generation of `ValidationError` within the builder's error so that `alloc::string` is avoided.

--- a/derive_builder/src/lib.rs
+++ b/derive_builder/src/lib.rs
@@ -645,13 +645,13 @@
 //! #[derive(Debug, PartialEq, Default, Builder, Clone)]
 //! #[builder(derive(Debug, PartialEq))]
 //! struct Lorem {
-//!     #[builder(setter(into), field(type = "u32"))]
+//!     #[builder(setter(into), field(ty = "u32"))]
 //!     ipsum: u32,
 //!
-//!     #[builder(field(type = "String", build = "()"))]
+//!     #[builder(field(ty = "String", build = "()"))]
 //!     dolor: (),
 //!
-//!     #[builder(field(type = "&'static str", build = "self.amet.parse()?"))]
+//!     #[builder(field(ty = "&'static str", build = "self.amet.parse()?"))]
 //!     amet: u32,
 //! }
 //!
@@ -670,7 +670,7 @@
 //! # }
 //! ```
 //!
-//! The builder field type (`type =`) must implement `Default`.
+//! The builder field type (`ty =`) must implement `Default`.
 //!
 //! The argument to `build` must be a literal string containing Rust code for the contents of a block, which must evaluate to the type of the target field.
 //! It may refer to the builder struct as `self`, use `?`, etc.

--- a/derive_builder/tests/builder_field_custom.rs
+++ b/derive_builder/tests/builder_field_custom.rs
@@ -7,10 +7,10 @@ use std::num::ParseIntError;
 
 #[derive(Debug, PartialEq, Default, Builder, Clone)]
 pub struct Lorem {
-    #[builder(field(type = "Option<usize>", build = "self.ipsum.unwrap_or(42) + 1"))]
+    #[builder(field(ty = "Option<usize>", build = "self.ipsum.unwrap_or(42) + 1"))]
     ipsum: usize,
 
-    #[builder(setter(into), field(type = "String", build = "self.dolor.parse()?"))]
+    #[builder(setter(into), field(ty = "String", build = "self.dolor.parse()?"))]
     dolor: u32,
 }
 

--- a/derive_builder/tests/compile-fail/builder_field_custom.rs
+++ b/derive_builder/tests/compile-fail/builder_field_custom.rs
@@ -10,12 +10,17 @@ pub struct Lorem {
     )]
     ipsum: usize,
 
-    // `default` is incompatible with `field.type`, even without `field.build`
-    #[builder(default = "2", field(type = "usize"))]
+    // Both `ty` and `type` are temporarily allowed to ease the transition
+    // to syn 2.0, but they are mutually exclusive.
+    #[builder(field(ty = "usize", type = "usize"))]
+    dolor: usize,
+
+    // `default` is incompatible with `field.ty`, even without `field.build`
+    #[builder(default = "2", field(ty = "usize"))]
     sit: usize,
 
     // Both errors can occur on the same field
-    #[builder(default = "3", field(type = "usize", build = "self.ipsum + 42"))]
+    #[builder(default = "3", field(ty = "usize", build = "self.ipsum + 42"))]
     amet: usize,
 }
 

--- a/derive_builder/tests/compile-fail/builder_field_custom.stderr
+++ b/derive_builder/tests/compile-fail/builder_field_custom.stderr
@@ -4,20 +4,26 @@ error: #[builder(default)] and #[builder(field(build="..."))] cannot be used tog
 8 |         default = "1",
   |                   ^^^
 
-error: #[builder(default)] and #[builder(field(type="..."))] cannot be used together
-  --> tests/compile-fail/builder_field_custom.rs:14:25
+error: duplicate field - `type` is a deprecated alias for `ty`.
+  --> tests/compile-fail/builder_field_custom.rs:15:35
    |
-14 |     #[builder(default = "2", field(type = "usize"))]
+15 |     #[builder(field(ty = "usize", type = "usize"))]
+   |                                   ^^^^
+
+error: #[builder(default)] and #[builder(field(type="..."))] cannot be used together
+  --> tests/compile-fail/builder_field_custom.rs:19:25
+   |
+19 |     #[builder(default = "2", field(ty = "usize"))]
    |                         ^^^
 
 error: #[builder(default)] and #[builder(field(build="..."))] cannot be used together
-  --> tests/compile-fail/builder_field_custom.rs:18:25
+  --> tests/compile-fail/builder_field_custom.rs:23:25
    |
-18 |     #[builder(default = "3", field(type = "usize", build = "self.ipsum + 42"))]
+23 |     #[builder(default = "3", field(ty = "usize", build = "self.ipsum + 42"))]
    |                         ^^^
 
 error: #[builder(default)] and #[builder(field(type="..."))] cannot be used together
-  --> tests/compile-fail/builder_field_custom.rs:18:25
+  --> tests/compile-fail/builder_field_custom.rs:23:25
    |
-18 |     #[builder(default = "3", field(type = "usize", build = "self.ipsum + 42"))]
+23 |     #[builder(default = "3", field(ty = "usize", build = "self.ipsum + 42"))]
    |                         ^^^


### PR DESCRIPTION
On syn 2.0, field(type = "...") will break with a not-very-informative error message.

While we can't prevent that, we can make it possible for people to switch to the new property name without needing to change anything else, so that the eventual dependency version bump is fully source-compatible.

# Alternatives Considered
I debated using `DeprecationNotes` to put a warning on all uses of `type`, but decided it wasn't worth the code churn necessary to plumb that through from the options area all the way to code generation. This is already a highly specialized feature, and the fix is pretty easy once you read the release notes.