### PR TITLE
Update to syn 2 and darling 0.20.5

### DIFF
--- a/derive_builder/Cargo.toml
+++ b/derive_builder/Cargo.toml
@@ -7,6 +7,7 @@ authors = [
     "Jan-Erik Rediger <janerik@fnordig.de>",
     "Ted Driggs <ted.driggs@outlook.com>",
 ]
+edition = "2018"
 
 description = "Rust macro to automatically implement the builder pattern for arbitrary structs."
 repository = "https://github.com/colin-kiegel/rust-derive-builder"

--- a/derive_builder/src/lib.rs
+++ b/derive_builder/src/lib.rs
@@ -728,7 +728,7 @@ pub use error::UninitializedFieldError;
 pub mod export {
     pub mod core {
         #[cfg(feature = "alloc")]
-        pub use alloc::string;
+        pub use ::alloc::string;
         #[cfg(not(feature = "std"))]
         pub use core::*;
         #[cfg(feature = "std")]

--- a/derive_builder/tests/builder_field_custom.rs
+++ b/derive_builder/tests/builder_field_custom.rs
@@ -7,10 +7,10 @@ use std::num::ParseIntError;
 
 #[derive(Debug, PartialEq, Default, Builder, Clone)]
 pub struct Lorem {
-    #[builder(field(ty = "Option<usize>", build = "self.ipsum.unwrap_or(42) + 1"))]
+    #[builder(field(ty = "Option<usize>", build = self.ipsum.unwrap_or(42) + 1))]
     ipsum: usize,
 
-    #[builder(setter(into), field(ty = "String", build = "self.dolor.parse()?"))]
+    #[builder(setter(into), field(ty = "String", build = self.dolor.parse()?))]
     dolor: u32,
 }
 

--- a/derive_builder/tests/compile-fail/builder_field_custom.rs
+++ b/derive_builder/tests/compile-fail/builder_field_custom.rs
@@ -10,11 +10,6 @@ pub struct Lorem {
     )]
     ipsum: usize,
 
-    // Both `ty` and `type` are temporarily allowed to ease the transition
-    // to syn 2.0, but they are mutually exclusive.
-    #[builder(field(ty = "usize", type = "usize"))]
-    dolor: usize,
-
     // `default` is incompatible with `field.ty`, even without `field.build`
     #[builder(default = "2", field(ty = "usize"))]
     sit: usize,

--- a/derive_builder/tests/compile-fail/builder_field_custom.stderr
+++ b/derive_builder/tests/compile-fail/builder_field_custom.stderr
@@ -4,26 +4,20 @@ error: #[builder(default)] and #[builder(field(build="..."))] cannot be used tog
 8 |         default = "1",
   |                   ^^^
 
-error: duplicate field - `type` is a deprecated alias for `ty`.
-  --> tests/compile-fail/builder_field_custom.rs:15:35
+error: #[builder(default)] and #[builder(field(ty="..."))] cannot be used together
+  --> tests/compile-fail/builder_field_custom.rs:14:25
    |
-15 |     #[builder(field(ty = "usize", type = "usize"))]
-   |                                   ^^^^
-
-error: #[builder(default)] and #[builder(field(type="..."))] cannot be used together
-  --> tests/compile-fail/builder_field_custom.rs:19:25
-   |
-19 |     #[builder(default = "2", field(ty = "usize"))]
+14 |     #[builder(default = "2", field(ty = "usize"))]
    |                         ^^^
 
 error: #[builder(default)] and #[builder(field(build="..."))] cannot be used together
-  --> tests/compile-fail/builder_field_custom.rs:23:25
+  --> tests/compile-fail/builder_field_custom.rs:18:25
    |
-23 |     #[builder(default = "3", field(ty = "usize", build = "self.ipsum + 42"))]
+18 |     #[builder(default = "3", field(ty = "usize", build = "self.ipsum + 42"))]
    |                         ^^^
 
-error: #[builder(default)] and #[builder(field(type="..."))] cannot be used together
-  --> tests/compile-fail/builder_field_custom.rs:23:25
+error: #[builder(default)] and #[builder(field(ty="..."))] cannot be used together
+  --> tests/compile-fail/builder_field_custom.rs:18:25
    |
-23 |     #[builder(default = "3", field(ty = "usize", build = "self.ipsum + 42"))]
+18 |     #[builder(default = "3", field(ty = "usize", build = "self.ipsum + 42"))]
    |                         ^^^

--- a/derive_builder/tests/compile-fail/crate_root.stderr
+++ b/derive_builder/tests/compile-fail/crate_root.stderr
@@ -13,9 +13,15 @@ error[E0433]: failed to resolve: could not find `export` in `empty`
   |          ^^^^^^^ not found in `empty::export::core::option`
   |
   = note: this error originates in the derive macro `Builder` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: consider importing this enum
+help: consider importing one of these items
+  |
+5 | use core::option::Option;
   |
 5 | use derive_builder::export::core::option::Option;
+  |
+5 | use serde::__private::Option;
+  |
+5 | use std::option::Option;
   |
 
 error[E0433]: failed to resolve: could not find `export` in `empty`
@@ -25,9 +31,15 @@ error[E0433]: failed to resolve: could not find `export` in `empty`
   |          ^^^^^^^ not found in `empty::export::core::clone`
   |
   = note: this error originates in the derive macro `Builder` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: consider importing this trait
+help: consider importing one of these items
+  |
+5 | use core::clone::Clone;
   |
 5 | use derive_builder::export::core::clone::Clone;
+  |
+5 | use serde::__private::Clone;
+  |
+5 | use std::clone::Clone;
   |
 
 error[E0433]: failed to resolve: could not find `export` in `empty`
@@ -39,14 +51,15 @@ error[E0433]: failed to resolve: could not find `export` in `empty`
   = note: this error originates in the derive macro `Builder` (in Nightly builds, run with -Z macro-backtrace for more info)
 help: consider importing one of these items
   |
+5 | use core::fmt::Result;
+  |
+5 | use core::result::Result;
+  |
 5 | use derive_builder::export::core::fmt::Result;
   |
 5 | use derive_builder::export::core::io::Result;
   |
-5 | use derive_builder::export::core::result::Result;
-  |
-5 | use derive_builder::export::core::thread::Result;
-  |
+    and 9 other candidates
 
 error[E0433]: failed to resolve: could not find `export` in `empty`
  --> tests/compile-fail/crate_root.rs:7:10
@@ -55,9 +68,15 @@ error[E0433]: failed to resolve: could not find `export` in `empty`
   |          ^^^^^^^ not found in `empty::export::core::convert`
   |
   = note: this error originates in the derive macro `Builder` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: consider importing this trait
+help: consider importing one of these items
+  |
+5 | use core::convert::Into;
   |
 5 | use derive_builder::export::core::convert::Into;
+  |
+5 | use serde::__private::Into;
+  |
+5 | use std::convert::Into;
   |
 
 error[E0433]: failed to resolve: could not find `UninitializedFieldError` in `empty`
@@ -79,9 +98,15 @@ error[E0433]: failed to resolve: could not find `export` in `empty`
   |          ^^^^^^^ not found in `empty::export::core::default`
   |
   = note: this error originates in the derive macro `Builder` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: consider importing this trait
+help: consider importing one of these items
+  |
+5 | use core::default::Default;
   |
 5 | use derive_builder::export::core::default::Default;
+  |
+5 | use serde::__private::Default;
+  |
+5 | use std::default::Default;
   |
 
 error[E0412]: cannot find type `UninitializedFieldError` in module `empty`

--- a/derive_builder_core/Cargo.toml
+++ b/derive_builder_core/Cargo.toml
@@ -7,7 +7,7 @@ authors = [
     "Jan-Erik Rediger <janerik@fnordig.de>",
     "Ted Driggs <ted.driggs@outlook.com>",
 ]
-
+edition = "2018"
 description = "Internal helper library for the derive_builder crate."
 repository = "https://github.com/colin-kiegel/rust-derive-builder"
 documentation = "https://docs.rs/derive_builder_core"
@@ -21,10 +21,10 @@ clippy = []
 lib_has_std = []
 
 [dependencies]
-darling = "0.14.0"
+darling = "0.20.5"
 proc-macro2 = "1.0.37"
-quote = "1.0.18"
-syn = { version = "1.0.91", features = ["full", "extra-traits"] }
+quote = "1.0.35"
+syn = { version = "2.0.15", features = ["full", "extra-traits"] }
 
 [dev-dependencies]
 pretty_assertions = "1.2.1"

--- a/derive_builder_core/Cargo.toml
+++ b/derive_builder_core/Cargo.toml
@@ -21,7 +21,7 @@ clippy = []
 lib_has_std = []
 
 [dependencies]
-darling = "0.20.5"
+darling = "0.20.6"
 proc-macro2 = "1.0.37"
 quote = "1.0.35"
 syn = { version = "2.0.15", features = ["full", "extra-traits"] }

--- a/derive_builder_core/src/block.rs
+++ b/derive_builder_core/src/block.rs
@@ -61,6 +61,14 @@ impl darling::FromMeta for BlockContents {
             Err(darling::Error::unexpected_lit_type(value))
         }
     }
+
+    fn from_expr(expr: &syn::Expr) -> darling::Result<Self> {
+        if let syn::Expr::Lit(lit) = expr {
+            Self::from_value(&lit.lit)
+        } else {
+            Ok(Self::from(expr.clone()))
+        }
+    }
 }
 
 #[cfg(test)]

--- a/derive_builder_core/src/block.rs
+++ b/derive_builder_core/src/block.rs
@@ -1,6 +1,6 @@
 use std::convert::TryFrom;
 
-use proc_macro2::TokenStream;
+use proc_macro2::{Span, TokenStream};
 use quote::ToTokens;
 use syn::{self, spanned::Spanned, Block, LitStr};
 
@@ -15,6 +15,10 @@ pub struct BlockContents(Block);
 impl BlockContents {
     pub fn is_empty(&self) -> bool {
         self.0.stmts.is_empty()
+    }
+
+    pub fn span(&self) -> Span {
+        self.0.span()
     }
 }
 
@@ -39,7 +43,7 @@ impl From<syn::Expr> for BlockContents {
     fn from(v: syn::Expr) -> Self {
         Self(Block {
             brace_token: syn::token::Brace(v.span()),
-            stmts: vec![syn::Stmt::Expr(v)],
+            stmts: vec![syn::Stmt::Expr(v, None)],
         })
     }
 }
@@ -71,7 +75,7 @@ mod test {
     }
 
     #[test]
-    #[should_panic(expected = r#"lex error"#)]
+    #[should_panic(expected = r#"cannot parse"#)]
     fn block_invalid_token_trees() {
         parse("let x = 2; { x+1").unwrap();
     }

--- a/derive_builder_core/src/build_method.rs
+++ b/derive_builder_core/src/build_method.rs
@@ -1,15 +1,12 @@
 use std::borrow::Cow;
 
-use doc_comment_from;
 use proc_macro2::{Span, TokenStream};
 use quote::{ToTokens, TokenStreamExt};
-use syn;
 use syn::spanned::Spanned;
-use BuilderPattern;
-use Initializer;
-use DEFAULT_STRUCT_NAME;
 
-use crate::DefaultExpression;
+use crate::{
+    doc_comment_from, BuilderPattern, DefaultExpression, Initializer, DEFAULT_STRUCT_NAME,
+};
 
 /// Initializer for the struct fields in the build method, implementing
 /// `quote::ToTokens`.

--- a/derive_builder_core/src/builder.rs
+++ b/derive_builder_core/src/builder.rs
@@ -5,12 +5,9 @@ use quote::{format_ident, ToTokens, TokenStreamExt};
 use syn::punctuated::Punctuated;
 use syn::{self, Path, TraitBound, TraitBoundModifier, TypeParamBound};
 
-use doc_comment_from;
-use BuildMethod;
-use BuilderField;
-use BuilderPattern;
-use DeprecationNotes;
-use Setter;
+use crate::{
+    doc_comment_from, BuildMethod, BuilderField, BuilderPattern, DeprecationNotes, Setter,
+};
 
 const ALLOC_NOT_ENABLED_ERROR: &str = r#"`alloc` is disabled within 'derive_builder', consider one of the following:
 * enable feature `alloc` on 'dervie_builder' if a `global_allocator` is present
@@ -858,7 +855,7 @@ mod tests {
 
                 add_simple_foo_builder(&mut result);
 
-                result.append_all(quote!(compile_error! { #ALLOC_NOT_ENABLED_ERROR }));
+                result.append_all(quote!(::core::compile_error! { #ALLOC_NOT_ENABLED_ERROR }));
 
                 result
             }

--- a/derive_builder_core/src/builder_field.rs
+++ b/derive_builder_core/src/builder_field.rs
@@ -2,7 +2,6 @@ use std::borrow::Cow;
 
 use proc_macro2::TokenStream;
 use quote::{ToTokens, TokenStreamExt};
-use syn;
 
 /// Field for the builder struct, implementing `quote::ToTokens`.
 ///

--- a/derive_builder_core/src/default_expression.rs
+++ b/derive_builder_core/src/default_expression.rs
@@ -23,6 +23,13 @@ impl DefaultExpression {
         }
     }
 
+    pub fn span(&self) -> Span {
+        match self {
+            DefaultExpression::Explicit(block) => block.span(),
+            DefaultExpression::Trait => Span::call_site(),
+        }
+    }
+
     #[cfg(test)]
     pub fn explicit<I: Into<BlockContents>>(content: I) -> Self {
         DefaultExpression::Explicit(content.into())
@@ -36,15 +43,6 @@ impl darling::FromMeta for DefaultExpression {
 
     fn from_value(value: &syn::Lit) -> darling::Result<Self> {
         Ok(Self::Explicit(BlockContents::from_value(value)?))
-    }
-}
-
-impl syn::spanned::Spanned for DefaultExpression {
-    fn span(&self) -> Span {
-        match self {
-            DefaultExpression::Explicit(block) => block.span(),
-            DefaultExpression::Trait => Span::call_site(),
-        }
     }
 }
 

--- a/derive_builder_core/src/deprecation_notes.rs
+++ b/derive_builder_core/src/deprecation_notes.rs
@@ -1,6 +1,5 @@
 use proc_macro2::{Span, TokenStream};
 use quote::{ToTokens, TokenStreamExt};
-use syn;
 
 /// Deprecation notes we want to emit to the user, implementing
 /// `quote::ToTokens`.

--- a/derive_builder_core/src/initializer.rs
+++ b/derive_builder_core/src/initializer.rs
@@ -1,10 +1,7 @@
 use proc_macro2::{Span, TokenStream};
 use quote::{ToTokens, TokenStreamExt};
-use syn;
-use BuilderPattern;
-use DEFAULT_STRUCT_NAME;
 
-use crate::{change_span, BlockContents, DefaultExpression};
+use crate::{change_span, BlockContents, BuilderPattern, DefaultExpression, DEFAULT_STRUCT_NAME};
 
 /// Initializer for the target struct fields, implementing `quote::ToTokens`.
 ///

--- a/derive_builder_core/src/macro_options/darling_opts.rs
+++ b/derive_builder_core/src/macro_options/darling_opts.rs
@@ -4,8 +4,7 @@ use crate::BuildMethod;
 
 use darling::util::{Flag, PathList, SpannedValue};
 use darling::{self, Error, FromMeta};
-use proc_macro2::{Span, TokenStream};
-use syn::parse::{ParseStream, Parser};
+use proc_macro2::Span;
 use syn::Meta;
 use syn::{self, spanned::Spanned, Attribute, Generics, Ident, Path};
 
@@ -62,7 +61,7 @@ fn no_visibility_conflict<T: Visibility>(v: &T) -> darling::Result<()> {
     } else if declares_public && declares_private {
         Err(
             Error::custom(r#"`public` and `private` cannot be used together"#)
-                .with_span(v.public()),
+                .with_span(&v.public().span()),
         )
     } else {
         Ok(())
@@ -103,7 +102,7 @@ impl FromMeta for BuildFnError {
         match item {
             Meta::Path(_) => Err(Error::unsupported_format("word").with_span(item)),
             Meta::List(_) => BuildFnErrorGenerated::from_meta(item).map(Self::Generated),
-            Meta::NameValue(i) => Path::from_value(&i.lit).map(Self::Existing),
+            Meta::NameValue(i) => Path::from_expr(&i.value).map(Self::Existing),
         }
     }
 }
@@ -112,7 +111,7 @@ impl FromMeta for BuildFnError {
 /// There is no inheritance for these settings from struct-level to field-level,
 /// so we don't bother using `Option` for values in this struct.
 #[derive(Debug, Clone, FromMeta)]
-#[darling(default, and_then = "Self::validation_needs_error")]
+#[darling(default, and_then = Self::validation_needs_error)]
 pub struct BuildFn {
     skip: bool,
     name: Ident,
@@ -155,7 +154,7 @@ impl BuildFn {
                         Error::custom(
                             "Cannot set `error(validation_error = false)` when using `validate`",
                         )
-                        .with_span(&e.validation_error),
+                        .with_span(&e.validation_error.span()),
                     )
                 }
             }
@@ -215,49 +214,21 @@ impl Visibility for StructLevelFieldMeta {
     }
 }
 
-fn preserve_field_span(meta: &Meta) -> darling::Result<(Span, syn::Type)> {
-    match meta {
-        Meta::Path(_) => Err(Error::unsupported_format("word").with_span(meta)),
-        Meta::List(_) => Err(Error::unsupported_format("list").with_span(meta)),
-        Meta::NameValue(mnv) => Ok((mnv.path.span(), syn::Type::from_value(&mnv.lit)?)),
-    }
-}
-
 /// Contents of the `field` meta in `builder` attributes at the field level.
 //
 // This is a superset of the attributes permitted in `field` at the struct level.
 // Perhaps in the future we will be able to use `#[darling(flatten)]`, but
 // that does not exist right now: https://github.com/TedDriggs/darling/issues/146
 #[derive(Debug, Clone, Default, FromMeta)]
-#[darling(and_then = "Self::finalize")]
 pub struct FieldLevelFieldMeta {
     public: Flag,
     private: Flag,
     vis: Option<syn::Visibility>,
-    #[darling(rename = "type", with = "preserve_field_span", map = "Some", default)]
-    builder_type_old: Option<(Span, syn::Type)>,
     /// Custom builder field type
     #[darling(rename = "ty")]
     builder_type: Option<syn::Type>,
     /// Custom builder field method, for making target struct field value
     build: Option<BlockContents>,
-}
-
-impl FieldLevelFieldMeta {
-    fn finalize(mut self) -> darling::Result<Self> {
-        if let Some((type_field_span, ty)) = self.builder_type_old.take() {
-            if self.builder_type.is_some() {
-                return Err(Error::custom(
-                    "duplicate field - `type` is a deprecated alias for `ty`.",
-                )
-                .with_span(&type_field_span));
-            }
-
-            self.builder_type = Some(ty);
-        }
-
-        Ok(self)
-    }
 }
 
 impl Visibility for FieldLevelFieldMeta {
@@ -298,14 +269,10 @@ impl StructLevelSetter {
 /// * `each(name = "...")`, which allows setting additional options on the `each` setter
 fn parse_each(meta: &Meta) -> darling::Result<Option<Each>> {
     if let Meta::NameValue(mnv) = meta {
-        if let syn::Lit::Str(v) = &mnv.lit {
-            v.parse::<Ident>()
-                .map(Each::from)
-                .map(Some)
-                .map_err(|_| darling::Error::unknown_value(&v.value()).with_span(v))
-        } else {
-            Err(darling::Error::unexpected_lit_type(&mnv.lit))
-        }
+        Ident::from_meta(meta)
+            .map(Each::from)
+            .map(Some)
+            .map_err(|e| e.with_span(&mnv.value))
     } else {
         Each::from_meta(meta).map(Some)
     }
@@ -322,7 +289,7 @@ pub struct FieldLevelSetter {
     strip_option: Option<bool>,
     skip: Option<bool>,
     custom: Option<bool>,
-    #[darling(with = "parse_each")]
+    #[darling(with = parse_each)]
     each: Option<Each>,
 }
 
@@ -453,19 +420,19 @@ impl Field {
                     darling::Error::custom(
                         r#"#[builder(default)] and #[builder(field(build="..."))] cannot be used together"#,
                     )
-                    .with_span(field_default),
+                    .with_span(&field_default.span()),
                 );
             }
 
-            // `field.type` being set means `default` will not be used, since we don't know how
+            // `field.ty` being set means `default` will not be used, since we don't know how
             // to check a custom field type for the absence of a value and therefore we'll never
             // know that we should use the `default` value.
             if self.field.builder_type.is_some() {
                 errors.push(
                     darling::Error::custom(
-                        r#"#[builder(default)] and #[builder(field(type="..."))] cannot be used together"#,
+                        r#"#[builder(default)] and #[builder(field(ty="..."))] cannot be used together"#,
                     )
-                    .with_span(field_default)
+                    .with_span(&field_default.span())
                 )
             }
         };
@@ -510,7 +477,7 @@ fn distribute_and_unnest_attrs(
     for attr in input.drain(..) {
         let destination = outputs
             .iter_mut()
-            .find(|(ptattr, _)| attr.path.is_ident(ptattr));
+            .find(|(ptattr, _)| attr.path().is_ident(ptattr));
 
         if let Some((_, destination)) = destination {
             match unnest_from_one_attribute(attr) {
@@ -537,7 +504,7 @@ fn unnest_from_one_attribute(attr: syn::Attribute) -> darling::Result<Attribute>
         syn::AttrStyle::Inner(bang) => {
             return Err(darling::Error::unsupported_format(&format!(
                 "{} must be an outer attribute",
-                attr.path
+                attr.path()
                     .get_ident()
                     .map(Ident::to_string)
                     .unwrap_or_else(|| "Attribute".to_string())
@@ -546,34 +513,19 @@ fn unnest_from_one_attribute(attr: syn::Attribute) -> darling::Result<Attribute>
         }
     };
 
-    #[derive(Debug)]
-    struct ContainedAttribute(syn::Attribute);
-    impl syn::parse::Parse for ContainedAttribute {
-        fn parse(input: ParseStream) -> syn::Result<Self> {
-            // Strip parentheses, and save the span of the parenthesis token
-            let content;
-            let paren_token = parenthesized!(content in input);
-            let wrap_span = paren_token.span;
+    let original_span = attr.span();
 
-            // Wrap up in #[ ] instead.
-            let pound = Token![#](wrap_span); // We can't write a literal # inside quote
-            let content: TokenStream = content.parse()?;
-            let content = quote_spanned!(wrap_span=> #pound [ #content ]);
+    let pound = attr.pound_token;
+    let meta = attr.meta;
 
-            let parser = syn::Attribute::parse_outer;
-            let mut attrs = parser.parse2(content)?.into_iter();
-            // TryFrom for Array not available in Rust 1.40
-            // We think this error can never actually happen, since `#[...]` ought to make just one Attribute
-            let attr = match (attrs.next(), attrs.next()) {
-                (Some(attr), None) => attr,
-                _ => return Err(input.error("expected exactly one attribute")),
-            };
-            Ok(Self(attr))
+    match meta {
+        Meta::Path(_) => Err(Error::unsupported_format("word").with_span(&meta)),
+        Meta::NameValue(_) => Err(Error::unsupported_format("name-value").with_span(&meta)),
+        Meta::List(list) => {
+            let inner = list.tokens;
+            Ok(parse_quote_spanned!(original_span=> #pound [ #inner ]))
         }
     }
-
-    let ContainedAttribute(attr) = syn::parse2(attr.tokens)?;
-    Ok(attr)
 }
 
 impl Visibility for Field {

--- a/derive_builder_core/src/macro_options/darling_opts.rs
+++ b/derive_builder_core/src/macro_options/darling_opts.rs
@@ -366,7 +366,7 @@ pub struct Field {
     visibility: Option<syn::Visibility>,
     // See the documentation for `FieldSetterMeta` to understand how `darling`
     // is interpreting this field.
-    #[darling(default, with = "field_setter")]
+    #[darling(default, with = field_setter)]
     setter: FieldLevelSetter,
     /// The value for this field if the setter is never invoked.
     ///
@@ -555,7 +555,7 @@ fn default_create_empty() -> Ident {
     attributes(builder),
     forward_attrs(cfg, allow, builder_struct_attr, builder_impl_attr),
     supports(struct_named),
-    and_then = "Self::unnest_attrs"
+    and_then = Self::unnest_attrs
 )]
 pub struct Options {
     ident: Ident,
@@ -584,7 +584,7 @@ pub struct Options {
 
     /// The path to the root of the derive_builder crate used in generated
     /// code.
-    #[darling(rename = "crate", default = "default_crate_root")]
+    #[darling(rename = "crate", default = default_crate_root)]
     crate_root: Path,
 
     #[darling(default)]
@@ -601,7 +601,7 @@ pub struct Options {
 
     /// The ident of the inherent method which takes no arguments and returns
     /// an instance of the builder with all fields empty.
-    #[darling(default = "default_create_empty")]
+    #[darling(default = default_create_empty)]
     create_empty: Ident,
 
     /// Setter options applied to all field setters in the struct.

--- a/derive_builder_core/src/setter.rs
+++ b/derive_builder_core/src/setter.rs
@@ -3,12 +3,8 @@ use std::borrow::Cow;
 
 use proc_macro2::{Span, TokenStream};
 use quote::{ToTokens, TokenStreamExt};
-use syn;
 
-use BuilderFieldType;
-use BuilderPattern;
-use DeprecationNotes;
-use Each;
+use crate::{BuilderFieldType, BuilderPattern, DeprecationNotes, Each};
 
 /// Setter for the struct fields in the build method, implementing
 /// `quote::ToTokens`.
@@ -243,7 +239,7 @@ fn wrap_expression_in_some(crate_root: &syn::Path, bare_value: impl ToTokens) ->
 // We cannot handle those arbitrary names.
 fn extract_type_from_option(ty: &syn::Type) -> Option<&syn::Type> {
     use syn::punctuated::Pair;
-    use syn::token::Colon2;
+    use syn::token::PathSep;
     use syn::{GenericArgument, Path, PathArguments, PathSegment};
 
     fn extract_type_path(ty: &syn::Type) -> Option<&Path> {
@@ -255,7 +251,7 @@ fn extract_type_from_option(ty: &syn::Type) -> Option<&syn::Type> {
 
     // TODO store (with lazy static) precomputed parsing of Option when support of rust 1.18 will be removed (incompatible with lazy_static)
     // TODO maybe optimization, reverse the order of segments
-    fn extract_option_segment(path: &Path) -> Option<Pair<&PathSegment, &Colon2>> {
+    fn extract_option_segment(path: &Path) -> Option<Pair<&PathSegment, &PathSep>> {
         let idents_of_path = path.segments.iter().fold(String::new(), |mut acc, v| {
             acc.push_str(&v.ident.to_string());
             acc.push('|');

--- a/derive_builder_macro/Cargo.toml
+++ b/derive_builder_macro/Cargo.toml
@@ -7,6 +7,7 @@ authors = [
     "Jan-Erik Rediger <janerik@fnordig.de>",
     "Ted Driggs <ted.driggs@outlook.com>",
 ]
+edition = "2018"
 
 description = "Rust macro to automatically implement the builder pattern for arbitrary structs."
 repository = "https://github.com/colin-kiegel/rust-derive-builder"
@@ -26,5 +27,5 @@ clippy = ["derive_builder_core/clippy"]
 lib_has_std = ["derive_builder_core/lib_has_std"]
 
 [dependencies]
-syn = { version = "1.0.91", features = ["full", "extra-traits"] }
 derive_builder_core = { version = "=0.13.1", path = "../derive_builder_core" }
+syn = { version = "2.0.15", features = ["full", "extra-traits"] }


### PR DESCRIPTION
This uses the most recent major version of `syn`, as well as the most recent version of `darling`.

# Breaking Changes
1. It's no longer possible to use `type` to override the type of a field; instead, `ty` must be used.

Fixes #292 