### PR TITLE
Reimplement attribute parsing without `darling`

### DIFF
--- a/derive_builder/tests/compile-fail/build_fn_error.stderr
+++ b/derive_builder/tests/compile-fail/build_fn_error.stderr
@@ -1,31 +1,23 @@
-error: Unknown field: `path`
+error: unrecognized derive_builder attribute
  --> tests/compile-fail/build_fn_error.rs:4:52
   |
 4 | #[builder(build_fn(error(validation_error = false, path = "hello")))]
   |                                                    ^^^^
 
-error: Cannot set `error(validation_error = false)` when using `validate`
-  --> tests/compile-fail/build_fn_error.rs:10:45
+error: `error(validation_error = false)` and `validate` cannot be used together
+  --> tests/compile-fail/build_fn_error.rs:10:53
    |
 10 | #[builder(build_fn(error(validation_error = false), validate = "hello"))]
-   |                                             ^^^^^
+   |                                                     ^^^^^^^^^^^^^^^^^^
 
-error: Unknown field: `path`
+error: unrecognized derive_builder attribute
   --> tests/compile-fail/build_fn_error.rs:16:26
    |
 16 | #[builder(build_fn(error(path = "hello")))]
    |                          ^^^^
 
-error: Missing field `validation_error` at build_fn/error
-  --> tests/compile-fail/build_fn_error.rs:15:10
-   |
-15 | #[derive(Builder)]
-   |          ^^^^^^^
-   |
-   = note: this error originates in the derive macro `Builder` (in Nightly builds, run with -Z macro-backtrace for more info)
-
-error: Missing field `validation_error`
-  --> tests/compile-fail/build_fn_error.rs:22:20
+error: unexpected end of input, expected nested attribute
+  --> tests/compile-fail/build_fn_error.rs:22:26
    |
 22 | #[builder(build_fn(error()))]
-   |                    ^^^^^
+   |                          ^

--- a/derive_builder/tests/compile-fail/builder_field_custom.stderr
+++ b/derive_builder/tests/compile-fail/builder_field_custom.stderr
@@ -1,23 +1,23 @@
 error: #[builder(default)] and #[builder(field(build="..."))] cannot be used together
- --> tests/compile-fail/builder_field_custom.rs:8:19
+ --> tests/compile-fail/builder_field_custom.rs:9:9
   |
-8 |         default = "1",
-  |                   ^^^
+9 |         field(build = "self.ipsum.map(|v| v + 42).unwrap_or(100)")
+  |         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: #[builder(default)] and #[builder(field(ty="..."))] cannot be used together
-  --> tests/compile-fail/builder_field_custom.rs:14:25
+  --> tests/compile-fail/builder_field_custom.rs:14:30
    |
 14 |     #[builder(default = "2", field(ty = "usize"))]
-   |                         ^^^
+   |                              ^^^^^^^^^^^^^^^^^^^
 
 error: #[builder(default)] and #[builder(field(build="..."))] cannot be used together
-  --> tests/compile-fail/builder_field_custom.rs:18:25
+  --> tests/compile-fail/builder_field_custom.rs:18:30
    |
 18 |     #[builder(default = "3", field(ty = "usize", build = "self.ipsum + 42"))]
-   |                         ^^^
+   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: #[builder(default)] and #[builder(field(ty="..."))] cannot be used together
-  --> tests/compile-fail/builder_field_custom.rs:18:25
+  --> tests/compile-fail/builder_field_custom.rs:18:30
    |
 18 |     #[builder(default = "3", field(ty = "usize", build = "self.ipsum + 42"))]
-   |                         ^^^
+   |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/derive_builder/tests/compile-fail/deny_empty_default.stderr
+++ b/derive_builder/tests/compile-fail/deny_empty_default.stderr
@@ -1,5 +1,5 @@
-error: Unknown literal value ``
- --> $DIR/deny_empty_default.rs:8:25
+error: unexpected end of input, expected expression
+ --> tests/compile-fail/deny_empty_default.rs:8:25
   |
 8 |     #[builder(default = "")]
   |                         ^^

--- a/derive_builder/tests/compile-fail/rename_setter_struct_level.stderr
+++ b/derive_builder/tests/compile-fail/rename_setter_struct_level.stderr
@@ -1,4 +1,4 @@
-error: Unknown field: `name`
+error: unrecognized derive_builder attribute
  --> tests/compile-fail/rename_setter_struct_level.rs:7:18
   |
 7 | #[builder(setter(name = "foo"))]

--- a/derive_builder/tests/compile-fail/vis_conflict.stderr
+++ b/derive_builder/tests/compile-fail/vis_conflict.stderr
@@ -1,32 +1,32 @@
-error: `public` and `private` cannot be used together
- --> tests/compile-fail/vis_conflict.rs:7:15
-  |
-7 |     #[builder(public, private)]
-  |               ^^^^^^
-
-error: `vis="..."` cannot be used with `public` or `private`
- --> tests/compile-fail/vis_conflict.rs:5:25
+error: this visibility conflicts with a `public` specified earlier
+ --> tests/compile-fail/vis_conflict.rs:5:19
   |
 5 | #[builder(public, vis = "pub(crate)")]
-  |                         ^^^^^^^^^^^^
+  |                   ^^^^^^^^^^^^^^^^^^
 
-error: `public` and `private` cannot be used together
+error: this visibility conflicts with a `public` specified earlier
+ --> tests/compile-fail/vis_conflict.rs:7:23
+  |
+7 |     #[builder(public, private)]
+  |                       ^^^^^^^
+
+error: this visibility conflicts with a `public` specified earlier
+  --> tests/compile-fail/vis_conflict.rs:12:19
+   |
+12 | #[builder(public, vis = "pub(crate)", build_fn(private, public))]
+   |                   ^^^^^^^^^^^^^^^^^^
+
+error: this visibility conflicts with a `private` specified earlier
   --> tests/compile-fail/vis_conflict.rs:12:57
    |
 12 | #[builder(public, vis = "pub(crate)", build_fn(private, public))]
    |                                                         ^^^^^^
 
-error: `vis="..."` cannot be used with `public` or `private`
-  --> tests/compile-fail/vis_conflict.rs:14:30
+error: this visibility conflicts with a `private` specified earlier
+  --> tests/compile-fail/vis_conflict.rs:14:24
    |
 14 |     #[builder(private, vis = "pub")]
-   |                              ^^^^^
-
-error: `vis="..."` cannot be used with `public` or `private`
-  --> tests/compile-fail/vis_conflict.rs:12:25
-   |
-12 | #[builder(public, vis = "pub(crate)", build_fn(private, public))]
-   |                         ^^^^^^^^^^^^
+   |                        ^^^^^^^^^^^
 
 error[E0433]: failed to resolve: use of undeclared type `ExampleBuilder`
   --> tests/compile-fail/vis_conflict.rs:19:5

--- a/derive_builder_core/Cargo.toml
+++ b/derive_builder_core/Cargo.toml
@@ -21,10 +21,9 @@ clippy = []
 lib_has_std = []
 
 [dependencies]
-darling = "0.20.6"
 proc-macro2 = "1.0.37"
 quote = "1.0.35"
-syn = { version = "2.0.15", features = ["full", "extra-traits"] }
+syn = { version = "2.0.49", features = ["full", "extra-traits"] }
 
 [dev-dependencies]
 pretty_assertions = "1.2.1"

--- a/derive_builder_core/src/build_method.rs
+++ b/derive_builder_core/src/build_method.rs
@@ -159,8 +159,8 @@ macro_rules! default_build_method {
 
 #[cfg(test)]
 mod tests {
-    #[allow(unused_imports)]
     use super::*;
+    use crate::BlockContents;
 
     #[test]
     fn std() {
@@ -184,7 +184,7 @@ mod tests {
     fn default_struct() {
         let mut build_method = default_build_method!();
         let alt_default =
-            DefaultExpression::explicit::<syn::Expr>(parse_quote!(Default::default()));
+            DefaultExpression::Explicit(BlockContents::new(parse_quote!({ Default::default() })));
         build_method.default_struct = Some(&alt_default);
 
         #[rustfmt::skip]

--- a/derive_builder_core/src/initializer.rs
+++ b/derive_builder_core/src/initializer.rs
@@ -319,7 +319,7 @@ mod tests {
     #[test]
     fn default_value() {
         let mut initializer = default_initializer!();
-        let default_value = DefaultExpression::explicit::<syn::Expr>(parse_quote!(42));
+        let default_value = DefaultExpression::Explicit(BlockContents::new(parse_quote!({ 42 })));
         initializer.default_value = Some(&default_value);
 
         assert_eq!(

--- a/derive_builder_core/src/lib.rs
+++ b/derive_builder_core/src/lib.rs
@@ -16,10 +16,6 @@
 //! [`derive_builder_core`]: https://!crates.io/crates/derive_builder_core
 
 #![deny(warnings, missing_docs)]
-#![cfg_attr(test, recursion_limit = "100")]
-
-#[macro_use]
-extern crate darling;
 
 extern crate proc_macro;
 extern crate proc_macro2;
@@ -49,7 +45,6 @@ pub(crate) use build_method::BuildMethod;
 pub(crate) use builder::Builder;
 pub(crate) use builder_field::{BuilderField, BuilderFieldType};
 pub(crate) use change_span::change_span;
-use darling::FromDeriveInput;
 pub(crate) use default_expression::DefaultExpression;
 pub(crate) use deprecation_notes::DeprecationNotes;
 pub(crate) use doc_comment::doc_comment_from;
@@ -63,9 +58,7 @@ const DEFAULT_STRUCT_NAME: &str = "__default";
 pub fn builder_for_struct(ast: syn::DeriveInput) -> proc_macro2::TokenStream {
     let opts = match macro_options::Options::from_derive_input(&ast) {
         Ok(val) => val,
-        Err(err) => {
-            return err.write_errors();
-        }
+        Err(err) => return err.into_compile_error(),
     };
 
     let mut builder = opts.as_builder();

--- a/derive_builder_core/src/macro_options/diagnostic.rs
+++ b/derive_builder_core/src/macro_options/diagnostic.rs
@@ -1,0 +1,21 @@
+pub struct Diagnostic {
+    err: Option<syn::Error>,
+}
+
+impl Diagnostic {
+    pub fn new() -> Self {
+        Diagnostic { err: None }
+    }
+
+    pub fn push(&mut self, err: syn::Error) {
+        if let Some(prev) = &mut self.err {
+            prev.combine(err);
+        } else {
+            self.err = Some(err);
+        }
+    }
+
+    pub fn take(&mut self) -> Option<syn::Error> {
+        self.err.take()
+    }
+}

--- a/derive_builder_core/src/macro_options/mod.rs
+++ b/derive_builder_core/src/macro_options/mod.rs
@@ -12,5 +12,34 @@
 //!    `FieldOptions` instances.
 
 mod darling_opts;
+mod diagnostic;
+
+use syn::meta::ParseNestedMeta;
+use syn::{LitBool, LitStr};
 
 pub use self::darling_opts::Options;
+pub use self::diagnostic::Diagnostic;
+
+pub(crate) fn set<T>(meta: &ParseNestedMeta, out: &mut Option<T>, value: T, diag: &mut Diagnostic) {
+    if out.is_some() {
+        diag.push(meta.error("duplicate attribute"));
+    } else {
+        *out = Some(value);
+    }
+}
+
+/// Parse boolean value for a nested attribute in one of the following forms:
+/// `k = true`, `k = "true"`, or just `k` which means true.
+pub(crate) fn parse_optional_bool(meta: &ParseNestedMeta) -> syn::Result<bool> {
+    if meta.input.peek(Token![=]) {
+        let value = meta.value()?;
+        let lit: LitBool = if value.peek(LitStr) {
+            value.parse::<LitStr>()?.parse()?
+        } else {
+            value.parse()?
+        };
+        Ok(lit.value)
+    } else {
+        Ok(true)
+    }
+}

--- a/derive_builder_core/src/options.rs
+++ b/derive_builder_core/src/options.rs
@@ -1,9 +1,13 @@
+use crate::macro_options::{parse_optional_bool, set, Diagnostic};
+use syn::meta::ParseNestedMeta;
+use syn::{token, Ident, LitStr};
+
 /// Controls the signature of a setter method,
 /// more specifically how `self` is passed and returned.
 ///
 /// It can also be generalized to methods with different parameter sets and
 /// return types, e.g. the `build()` method.
-#[derive(PartialEq, Eq, Debug, Clone, Copy, FromMeta)]
+#[derive(PartialEq, Eq, Debug, Clone, Copy)]
 pub enum BuilderPattern {
     /// E.g. `fn bar(self, bar: Bar) -> Self`.
     Owned,
@@ -20,6 +24,23 @@ pub enum BuilderPattern {
 }
 
 impl BuilderPattern {
+    pub(crate) fn parse_nested_meta(
+        meta: &ParseNestedMeta,
+        diag: &mut Diagnostic,
+    ) -> syn::Result<Self> {
+        let lit: LitStr = meta.value()?.parse()?;
+        Ok(match lit.value().as_str() {
+            "owned" => BuilderPattern::Owned,
+            "mutable" => BuilderPattern::Mutable,
+            "immutable" => BuilderPattern::Immutable,
+            unknown => {
+                let msg = format!("unknown literal value `{}`", unknown);
+                diag.push(syn::Error::new(lit.span(), msg));
+                Self::default()
+            }
+        })
+    }
+
     /// Returns true if this style of builder needs to be able to clone its
     /// fields during the `build` method.
     pub fn requires_clone(&self) -> bool {
@@ -34,15 +55,51 @@ impl Default for BuilderPattern {
     }
 }
 
-#[derive(Debug, Clone, FromMeta)]
+#[derive(Debug, Clone)]
 pub struct Each {
     pub name: syn::Ident,
-    #[darling(default)]
     pub into: bool,
 }
 
-impl From<syn::Ident> for Each {
-    fn from(name: syn::Ident) -> Self {
-        Self { name, into: false }
+impl Each {
+    /// Create `Each` from an attribute's `Meta`.
+    ///
+    /// Two formats are supported:
+    ///
+    /// * `each = "..."`, which provides the name of the `each` setter and otherwise uses default values
+    /// * `each(name = "...")`, which allows setting additional options on the `each` setter
+    pub(crate) fn parse_nested_meta(
+        meta: &ParseNestedMeta,
+        diag: &mut Diagnostic,
+    ) -> syn::Result<Self> {
+        let lookahead = meta.input.lookahead1();
+        if lookahead.peek(Token![=]) {
+            let name: Ident = meta.value()?.parse::<LitStr>()?.parse()?;
+            return Ok(Each { name, into: false });
+        } else if !lookahead.peek(token::Paren) {
+            return Err(lookahead.error());
+        }
+
+        let mut name: Option<syn::Ident> = None;
+        let mut into: Option<bool> = None;
+
+        meta.parse_nested_meta(|meta| {
+            if meta.path.is_ident("name") {
+                let value: Ident = meta.value()?.parse::<LitStr>()?.parse()?;
+                set(&meta, &mut name, value, diag);
+            } else if meta.path.is_ident("into") {
+                let value = parse_optional_bool(&meta)?;
+                set(&meta, &mut into, value, diag);
+            } else {
+                return Err(meta.error("unrecognized derive_builder attribute"));
+            }
+            Ok(())
+        })?;
+
+        Ok(Each {
+            name: name
+                .ok_or_else(|| syn::Error::new_spanned(&meta.path, "missing attribute `name`"))?,
+            into: into.unwrap_or(false),
+        })
     }
 }

--- a/derive_builder_macro/Cargo.toml
+++ b/derive_builder_macro/Cargo.toml
@@ -28,4 +28,4 @@ lib_has_std = ["derive_builder_core/lib_has_std"]
 
 [dependencies]
 derive_builder_core = { version = "=0.20.0", path = "../derive_builder_core" }
-syn = { version = "2.0.15", features = ["full", "extra-traits"] }
+syn = { version = "2.0.49", features = ["full", "extra-traits"] }


### PR DESCRIPTION
This PR reimplements parsing using Syn's attribute parsing library, which lifts a few limitations previously imposed on derive_builder's implementation by `darling`.

- Keywords in attributes: `darling` doesn't make it possible to use keywords in a nested attribute, such as `field(type = "...")`. I have added back support for that syntax in this PR (but also kept `field(ty = "...")` as an alias for the same thing for backward compatibility).
https://github.com/TedDriggs/darling/issues/238

- Factoring commonality from different data structures: for this PR I have not gone overboard with refactoring, but I did move the trio of `public` + `private` + `vis = "..."` to a single central place, as it was repeated across 5 different structs. This PR unlocks additional possibilities for factoring out common behavior, and there are [pre-existing comments](https://github.com/colin-kiegel/rust-derive-builder/blob/07b8bcf00e1f9156da83cb4a01e0df50fa23cc20/derive_builder_core/src/macro_options/darling_opts.rs#L219-L221) to the effect that this would be desirable.
https://github.com/TedDriggs/darling/issues/146

- Validation during parse: with `darling`, structs are created in a potentially invalid state and then [code needs to crawl them after the fact](https://github.com/colin-kiegel/rust-derive-builder/blob/07b8bcf00e1f9156da83cb4a01e0df50fa23cc20/derive_builder_core/src/macro_options/darling_opts.rs#L670-L675) to perform validation. In this PR, structs do not get constructed in an invalid state; validation is integrated with the parsing. This also means various ["DO NOT USE"](https://github.com/colin-kiegel/rust-derive-builder/blob/07b8bcf00e1f9156da83cb4a01e0df50fa23cc20/derive_builder_core/src/macro_options/darling_opts.rs#L563-L568) fields go away in this PR.

- Passing state from outer contexts to inner: derive_builder has [workarounds](https://github.com/colin-kiegel/rust-derive-builder/blob/07b8bcf00e1f9156da83cb4a01e0df50fa23cc20/derive_builder_core/src/default_expression.rs#L16-L18) that exist because `darling`'s FromMeta needs to be able to fully construct the output with no context other than the input Meta. In this PR, parsing is handled top to bottom by free-form function calls; additional arguments can be passed through as it becomes useful. For example, one can parse attributes at the struct level and then pass data from those to the code that parses attributes at the field level.

- Compile time: this PR improves compile time of derive_builder by 35% on my machine (5.9 seconds to 3.8 seconds).