### PR TITLE
Resolve prelude redundant import warnings in nightly

### DIFF
--- a/derive_builder/tests/try_setter.rs
+++ b/derive_builder/tests/try_setter.rs
@@ -4,7 +4,6 @@ extern crate derive_builder;
 use std::convert::TryFrom;
 use std::net::{AddrParseError, IpAddr};
 use std::str::FromStr;
-use std::string::ToString;
 
 #[derive(Debug, Clone, PartialEq)]
 pub struct MyAddr(IpAddr);

--- a/derive_builder_core/src/block.rs
+++ b/derive_builder_core/src/block.rs
@@ -2,7 +2,7 @@ use std::convert::TryFrom;
 
 use proc_macro2::{Span, TokenStream};
 use quote::ToTokens;
-use syn::{self, spanned::Spanned, Block, LitStr};
+use syn::{spanned::Spanned, Block, LitStr};
 
 /// A wrapper for expressions/blocks which automatically adds the start and end
 /// braces.
@@ -76,7 +76,6 @@ mod test {
     use std::convert::TryInto;
 
     use super::*;
-    use proc_macro2::Span;
 
     fn parse(s: &str) -> Result<BlockContents, syn::Error> {
         (&LitStr::new(s, Span::call_site())).try_into()

--- a/derive_builder_core/src/builder.rs
+++ b/derive_builder_core/src/builder.rs
@@ -3,7 +3,7 @@ use std::borrow::Cow;
 use proc_macro2::TokenStream;
 use quote::{format_ident, ToTokens, TokenStreamExt};
 use syn::punctuated::Punctuated;
-use syn::{self, Path, TraitBound, TraitBoundModifier, TypeParamBound};
+use syn::{Path, TraitBound, TraitBoundModifier, TypeParamBound};
 
 use crate::{
     doc_comment_from, BuildMethod, BuilderField, BuilderPattern, DeprecationNotes, Setter,
@@ -405,7 +405,6 @@ macro_rules! default_builder {
 mod tests {
     #[allow(unused_imports)]
     use super::*;
-    use proc_macro2::TokenStream;
     use syn::Ident;
 
     fn add_simple_foo_builder(result: &mut TokenStream) {

--- a/derive_builder_core/src/macro_options/darling_opts.rs
+++ b/derive_builder_core/src/macro_options/darling_opts.rs
@@ -3,10 +3,9 @@ use std::{borrow::Cow, vec::IntoIter};
 use crate::BuildMethod;
 
 use darling::util::{Flag, PathList, SpannedValue};
-use darling::{self, Error, FromMeta};
+use darling::{Error, FromMeta};
 use proc_macro2::Span;
-use syn::Meta;
-use syn::{self, spanned::Spanned, Attribute, Generics, Ident, Path};
+use syn::{spanned::Spanned, Attribute, Generics, Ident, Meta, Path};
 
 use crate::{
     BlockContents, Builder, BuilderField, BuilderFieldType, BuilderPattern, DefaultExpression,


### PR DESCRIPTION
New warnings in nightly since https://github.com/rust-lang/rust/pull/117772. With `deny(warnings)`, this is causing CI to fail.

```console
error: the item `syn` is imported redundantly
  --> derive_builder_core/src/block.rs:5:11
   |
5  | use syn::{self, spanned::Spanned, Block, LitStr};
   |           ^^^^
   |
  ::: derive_builder_core/src/lib.rs:27:1
   |
27 | extern crate syn;
   | ----------------- the item `syn` is already imported here
   |
note: the lint level is defined here
  --> derive_builder_core/src/lib.rs:18:9
   |
18 | #![deny(warnings, missing_docs)]
   |         ^^^^^^^^
   = note: `#[deny(unused_imports)]` implied by `#[deny(warnings)]`

error: the item `syn` is imported redundantly
  --> derive_builder_core/src/builder.rs:6:11
   |
6  | use syn::{self, Path, TraitBound, TraitBoundModifier, TypeParamBound};
   |           ^^^^
   |
  ::: derive_builder_core/src/lib.rs:27:1
   |
27 | extern crate syn;
   | ----------------- the item `syn` is already imported here

error: the item `darling` is imported redundantly
  --> derive_builder_core/src/macro_options/darling_opts.rs:6:15
   |
6  | use darling::{self, Error, FromMeta};
   |               ^^^^
   |
  ::: derive_builder_core/src/lib.rs:22:1
   |
22 | extern crate darling;
   | --------------------- the item `darling` is already imported here

error: the item `syn` is imported redundantly
  --> derive_builder_core/src/macro_options/darling_opts.rs:9:11
   |
9  | use syn::{self, spanned::Spanned, Attribute, Generics, Ident, Path};
   |           ^^^^
   |
  ::: derive_builder_core/src/lib.rs:27:1
   |
27 | extern crate syn;
   | ----------------- the item `syn` is already imported here
```