### PR TITLE
Use darling's `with` to handle unnesting attrs

### DIFF
--- a/derive_builder_core/Cargo.toml
+++ b/derive_builder_core/Cargo.toml
@@ -21,7 +21,7 @@ clippy = []
 lib_has_std = []
 
 [dependencies]
-darling = "0.20.7"
+darling = "0.20.8"
 proc-macro2 = "1.0.37"
 quote = "1.0.35"
 syn = { version = "2.0.15", features = ["full", "extra-traits"] }


### PR DESCRIPTION
Before darling 0.20.8, the receiver struct had to take the forwarded attributes without transformation. That led to the options structs having a field called attrs that was drained during FromDeriveInput/FromField execution, and was vestigial on the finished struct.

The new approach instead does that transformation in the attrs field, resulting in an emitted type that is cleaner and more obvious to use.