### PR TITLE
Support for custom default fuction with owned pattern

### DIFF
--- a/derive_builder/CHANGELOG.md
+++ b/derive_builder/CHANGELOG.md
@@ -2,6 +2,9 @@
 All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## [Unreleased]
+- Allow default values that access `self` in combination with the "owned" pattern. #298
+
 ## [0.20.0] - 2024-02-14
 - Bump `syn` to version 2 #308
 - Bump `darling` to version 0.20.6 #308

--- a/derive_builder/tests/compile-fail/crate_root.stderr
+++ b/derive_builder/tests/compile-fail/crate_root.stderr
@@ -28,24 +28,6 @@ error[E0433]: failed to resolve: could not find `export` in `empty`
  --> tests/compile-fail/crate_root.rs:7:10
   |
 7 | #[derive(Builder)]
-  |          ^^^^^^^ not found in `empty::export::core::clone`
-  |
-  = note: this error originates in the derive macro `Builder` (in Nightly builds, run with -Z macro-backtrace for more info)
-help: consider importing one of these items
-  |
-5 | use core::clone::Clone;
-  |
-5 | use derive_builder::export::core::clone::Clone;
-  |
-5 | use serde::__private::Clone;
-  |
-5 | use std::clone::Clone;
-  |
-
-error[E0433]: failed to resolve: could not find `export` in `empty`
- --> tests/compile-fail/crate_root.rs:7:10
-  |
-7 | #[derive(Builder)]
   |          ^^^^^^^ not found in `empty::export::core::result`
   |
   = note: this error originates in the derive macro `Builder` (in Nightly builds, run with -Z macro-backtrace for more info)
@@ -89,6 +71,24 @@ error[E0433]: failed to resolve: could not find `UninitializedFieldError` in `em
 help: consider importing this struct
   |
 5 | use derive_builder::UninitializedFieldError;
+  |
+
+error[E0433]: failed to resolve: could not find `export` in `empty`
+ --> tests/compile-fail/crate_root.rs:7:10
+  |
+7 | #[derive(Builder)]
+  |          ^^^^^^^ not found in `empty::export::core::clone`
+  |
+  = note: this error originates in the derive macro `Builder` (in Nightly builds, run with -Z macro-backtrace for more info)
+help: consider importing one of these items
+  |
+5 | use core::clone::Clone;
+  |
+5 | use derive_builder::export::core::clone::Clone;
+  |
+5 | use serde::__private::Clone;
+  |
+5 | use std::clone::Clone;
   |
 
 error[E0433]: failed to resolve: could not find `export` in `empty`

--- a/derive_builder_core/src/build_method.rs
+++ b/derive_builder_core/src/build_method.rs
@@ -165,8 +165,7 @@ macro_rules! default_build_method {
             target_ty_generics: None,
             error_ty: syn::parse_quote!(FooBuilderError),
             initializers: vec![quote!(foo: self.foo,)],
-            defaults: vec![quote!(todo!("default value"))], // TODO what is the correct default for
-                                                            // test
+            defaults: vec![quote!()],
             doc_comment: None,
             default_struct: None,
             validate_fn: None,

--- a/derive_builder_core/src/field_default_value.rs
+++ b/derive_builder_core/src/field_default_value.rs
@@ -1,0 +1,191 @@
+use proc_macro2::{Ident, Span, TokenStream};
+use quote::{ToTokens, TokenStreamExt};
+use syn::Type;
+
+use crate::{
+    change_span, BlockContents, DefaultExpression, DEFAULT_FIELD_NAME_PREFIX, DEFAULT_STRUCT_NAME,
+};
+
+// TODO: remove no longer needed code from Initializer
+#[derive(Debug, Clone)]
+pub struct FieldDefaultValue<'a> {
+    /// Path to the root of the derive_builder crate.
+    pub crate_root: &'a syn::Path,
+    /// Name of the target field.
+    pub field_ident: &'a syn::Ident,
+    /// Type of the builder field.
+    pub field_type: &'a Type,
+    /// Whether the builder implements a setter for this field.
+    pub field_enabled: bool,
+    /// Default value for the target field.
+    ///
+    /// This takes precedence over a default struct identifier.
+    pub default_value: Option<&'a DefaultExpression>,
+    /// Whether the build_method defines a default struct.
+    pub use_default_struct: bool,
+    /// Span where the macro was told to use a preexisting error type, instead of creating one,
+    /// to represent failures of the `build` method.
+    ///
+    /// An initializer can force early-return if a field has no set value and no default is
+    /// defined. In these cases, it will convert from `derive_builder::UninitializedFieldError`
+    /// into the return type of its enclosing `build` method. That conversion is guaranteed to
+    /// work for generated error types, but if the caller specified an error type to use instead
+    /// they may have forgotten the conversion from `UninitializedFieldError` into their specified
+    /// error type.
+    pub custom_error_type_span: Option<Span>,
+    /// Method to use to to convert the builder's field to the target field
+    ///
+    /// For sub-builder fields, this will be `build` (or similar)
+    pub conversion: FieldConversion<'a>,
+}
+
+impl<'a> ToTokens for FieldDefaultValue<'a> {
+    fn to_tokens(&self, tokens: &mut proc_macro2::TokenStream) {
+        // should be:
+        // ```
+        // let $prefix$fieldname = match self.$field.as_ref() {
+        //      Some(_) => None,
+        //      None => Some($default_value)
+        //  }
+        //  ```
+
+        let struct_field = &self.field_ident;
+        let builder_field = struct_field;
+
+        let field_type = &self.field_type;
+
+        let default_value = Ident::new(
+            &format!("{}{}", DEFAULT_FIELD_NAME_PREFIX, struct_field),
+            Span::call_site(),
+        );
+
+        // token stream to generate the calculation of the default value
+        let default_calculation = (|| {
+            let mut tokens = TokenStream::new();
+            if !self.field_enabled {
+                // If the field is disabled we just calculate the default here.
+                // It is later set in the initializer
+                let value = self.disabled_field_value();
+                tokens.append_all(quote!(#value));
+            } else {
+                match &self.conversion {
+                    FieldConversion::Block(_) | FieldConversion::Move => {
+                        // value is directly accessed, therfor there is no default
+                        tokens.append_all(quote!(None))
+                    }
+                    FieldConversion::OptionOrDefault => {
+                        let default = self.default_value();
+                        tokens.append_all(quote!(#default));
+                    }
+                }
+            }
+            tokens
+        })();
+
+        tokens.append_all(quote!(
+            let #default_value: Option<#field_type> = match self.#builder_field.as_ref() {
+                Some(_) => None,
+                None => #default_calculation,
+            };
+        ));
+    }
+}
+
+impl<'a> FieldDefaultValue<'a> {
+    fn disabled_field_value(&'a self) -> TokenStream {
+        let crate_root = self.crate_root;
+        match self.default_value {
+            Some(expr) => expr.with_crate_root(crate_root).into_token_stream(),
+            None if self.use_default_struct => {
+                let struct_ident = syn::Ident::new(DEFAULT_STRUCT_NAME, Span::call_site());
+                let field_ident = self.field_ident;
+                quote!(#struct_ident.#field_ident)
+            }
+            None => {
+                quote!(#crate_root::export::core::default::Default::default())
+            }
+        }
+    }
+    fn default_value(&'a self) -> DefaultValue<'a> {
+        match self.default_value {
+            Some(expr) => DefaultValue::DefaultTo {
+                expr,
+                crate_root: self.crate_root,
+            },
+            None => {
+                if self.use_default_struct {
+                    DefaultValue::UseDefaultStructField(self.field_ident)
+                } else {
+                    DefaultValue::ReturnError {
+                        crate_root: self.crate_root,
+                        field_name: self.field_ident.to_string(),
+                        span: self.custom_error_type_span,
+                    }
+                }
+            }
+        }
+    }
+}
+
+enum DefaultValue<'a> {
+    /// Inner value must be a valid Rust expression
+    DefaultTo {
+        expr: &'a DefaultExpression,
+        crate_root: &'a syn::Path,
+    },
+    /// Inner value must be the field identifier
+    ///
+    /// The default struct must be in scope in the build_method.
+    UseDefaultStructField(&'a syn::Ident),
+    /// Inner value must be the field name
+    ReturnError {
+        crate_root: &'a syn::Path,
+        field_name: String,
+        span: Option<Span>,
+    },
+}
+
+impl<'a> ToTokens for DefaultValue<'a> {
+    fn to_tokens(&self, tokens: &mut TokenStream) {
+        match *self {
+            DefaultValue::DefaultTo { expr, crate_root } => {
+                let expr = expr.with_crate_root(crate_root);
+                tokens.append_all(quote!(Some(#expr)));
+            }
+            DefaultValue::UseDefaultStructField(field_ident) => {
+                let struct_ident = syn::Ident::new(DEFAULT_STRUCT_NAME, Span::call_site());
+                tokens.append_all(quote!(
+                    Some(#struct_ident.#field_ident)
+                ))
+            }
+            DefaultValue::ReturnError {
+                ref field_name,
+                ref span,
+                crate_root,
+            } => {
+                let conv_span = span.unwrap_or_else(Span::call_site);
+                // If the conversion fails, the compiler error should point to the error declaration
+                // rather than the crate root declaration, but the compiler will see the span of #crate_root
+                // and produce an undesired behavior (possibly because that's the first span in the bad expression?).
+                // Creating a copy with deeply-rewritten spans preserves the desired error behavior.
+                let crate_root = change_span(crate_root.into_token_stream(), conv_span);
+                let err_conv = quote_spanned!(conv_span => #crate_root::export::core::convert::Into::into(
+                    #crate_root::UninitializedFieldError::from(#field_name)
+                ));
+                tokens.append_all(quote!(
+                    return #crate_root::export::core::result::Result::Err(#err_conv)
+                ));
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub enum FieldConversion<'a> {
+    /// Usual conversion: unwrap the Option from the builder, or (hope to) use a default value
+    OptionOrDefault,
+    /// Custom conversion is a block contents expression
+    Block(&'a BlockContents),
+    /// Custom conversion is just to move the field from the builder
+    Move,
+}

--- a/derive_builder_core/src/field_default_value.rs
+++ b/derive_builder_core/src/field_default_value.rs
@@ -89,12 +89,7 @@ impl<'a> ToTokens for FieldDefaultValue<'a> {
             Span::call_site(),
         );
 
-        let default_calculation = (|| {
-            let mut tokens = TokenStream::new();
-            let default = self.default_value();
-            tokens.append_all(quote!(#default));
-            tokens
-        })();
+        let default_calculation = self.default_value();
 
         tokens.append_all(quote!(
             let #default_value: Option<#field_type> = match self.#builder_field.as_ref() {

--- a/derive_builder_core/src/initializer.rs
+++ b/derive_builder_core/src/initializer.rs
@@ -154,12 +154,9 @@ mod tests {
         assert_eq!(
             quote!(#initializer).to_string(),
             quote!(
-                foo: match self.foo {
-                    Some(ref value) => ::db::export::core::clone::Clone::clone(value),
-                    None => return ::db::export::core::result::Result::Err(::db::export::core::convert::Into::into(
-                        ::db::UninitializedFieldError::from("foo")
-                    )),
-                },
+               foo: self.foo.as_ref()
+                   .map(|value| ::db::export::core::clone::Clone::clone(value))
+                   .or(__default_foo).unwrap(),
             )
             .to_string()
         );
@@ -173,12 +170,9 @@ mod tests {
         assert_eq!(
             quote!(#initializer).to_string(),
             quote!(
-                foo: match self.foo {
-                    Some(ref value) => ::db::export::core::clone::Clone::clone(value),
-                    None => return ::db::export::core::result::Result::Err(::db::export::core::convert::Into::into(
-                        ::db::UninitializedFieldError::from("foo")
-                    )),
-                },
+                foo: self.foo.as_ref()
+                    .map(|value| ::db::export::core::clone::Clone::clone(value))
+                    .or(__default_foo).unwrap(),
             )
             .to_string()
         );
@@ -192,12 +186,7 @@ mod tests {
         assert_eq!(
             quote!(#initializer).to_string(),
             quote!(
-                foo: match self.foo {
-                    Some(value) => value,
-                    None => return ::db::export::core::result::Result::Err(::db::export::core::convert::Into::into(
-                        ::db::UninitializedFieldError::from("foo")
-                    )),
-                },
+                foo: self.foo.or(__default_foo).unwrap(),
             )
             .to_string()
         );
@@ -206,16 +195,14 @@ mod tests {
     #[test]
     fn default_value() {
         let mut initializer = default_initializer!();
+        initializer.field_enabled = false;
         let default_value = DefaultExpression::explicit::<syn::Expr>(parse_quote!(42));
         initializer.default_value = Some(&default_value);
 
         assert_eq!(
             quote!(#initializer).to_string(),
             quote!(
-                foo: match self.foo {
-                    Some(ref value) => ::db::export::core::clone::Clone::clone(value),
-                    None => { 42 },
-                },
+                foo: { 42 },
             )
             .to_string()
         );
@@ -224,15 +211,13 @@ mod tests {
     #[test]
     fn default_struct() {
         let mut initializer = default_initializer!();
+        initializer.field_enabled = false;
         initializer.use_default_struct = true;
 
         assert_eq!(
             quote!(#initializer).to_string(),
             quote!(
-                foo: match self.foo {
-                    Some(ref value) => ::db::export::core::clone::Clone::clone(value),
-                    None => __default.foo,
-                },
+                foo:  __default.foo,
             )
             .to_string()
         );
@@ -256,12 +241,9 @@ mod tests {
         assert_eq!(
             quote!(#initializer).to_string(),
             quote!(
-                foo: match self.foo {
-                    Some(ref value) => ::db::export::core::clone::Clone::clone(value),
-                    None => return ::db::export::core::result::Result::Err(::db::export::core::convert::Into::into(
-                        ::db::UninitializedFieldError::from("foo")
-                    )),
-                },
+                foo: self.foo.as_ref()
+                    .map(|value| ::db::export::core::clone::Clone::clone(value))
+                    .or(__default_foo).unwrap(),
             )
             .to_string()
         );

--- a/derive_builder_core/src/initializer.rs
+++ b/derive_builder_core/src/initializer.rs
@@ -1,7 +1,7 @@
-use proc_macro2::{Span, TokenStream};
+use proc_macro2::{Ident, Span, TokenStream};
 use quote::{ToTokens, TokenStreamExt};
 
-use crate::{change_span, BlockContents, BuilderPattern, DefaultExpression, DEFAULT_STRUCT_NAME};
+use crate::{BuilderPattern, DefaultExpression, FieldConversion, DEFAULT_FIELD_NAME_PREFIX};
 
 /// Initializer for the target struct fields, implementing `quote::ToTokens`.
 ///
@@ -34,12 +34,15 @@ use crate::{change_span, BlockContents, BuilderPattern, DefaultExpression, DEFAU
 /// ```
 #[derive(Debug, Clone)]
 pub struct Initializer<'a> {
-    /// Path to the root of the derive_builder crate.
-    pub crate_root: &'a syn::Path,
     /// Name of the target field.
     pub field_ident: &'a syn::Ident,
     /// Whether the builder implements a setter for this field.
     pub field_enabled: bool,
+
+    // TODO delete fields below here
+    //
+    /// Path to the root of the derive_builder crate.
+    pub crate_root: &'a syn::Path,
     /// How the build method takes and returns `self` (e.g. mutably).
     pub builder_pattern: BuilderPattern,
     /// Default value for the target field.
@@ -53,7 +56,7 @@ pub struct Initializer<'a> {
     ///
     /// An initializer can force early-return if a field has no set value and no default is
     /// defined. In these cases, it will convert from `derive_builder::UninitializedFieldError`
-    /// into the return type of its enclosing `build` method. That conversion is guaranteed to
+    /// into thereturn type of its enclosing `build` method. That conversion is guaranteed to
     /// work for generated error types, but if the caller specified an error type to use instead
     /// they may have forgotten the conversion from `UninitializedFieldError` into their specified
     /// error type.
@@ -69,167 +72,23 @@ impl<'a> ToTokens for Initializer<'a> {
         let struct_field = &self.field_ident;
         let builder_field = struct_field;
 
+        let default_value = Ident::new(
+            &format!("{}{}", DEFAULT_FIELD_NAME_PREFIX, struct_field),
+            Span::call_site(),
+        );
+
         // This structure prevents accidental failure to add the trailing `,` due to incautious `return`
         let append_rhs = |tokens: &mut TokenStream| {
             if !self.field_enabled {
-                let default = self.default();
-                tokens.append_all(quote!(
-                    #default
-                ));
+                tokens.append_all(quote!(#default_value));
             } else {
-                match &self.conversion {
-                    FieldConversion::Block(conv) => {
-                        conv.to_tokens(tokens);
-                    }
-                    FieldConversion::Move => tokens.append_all(quote!( self.#builder_field )),
-                    FieldConversion::OptionOrDefault => {
-                        let match_some = self.match_some();
-                        let match_none = self.match_none();
-                        tokens.append_all(quote!(
-                            match self.#builder_field {
-                                #match_some,
-                                #match_none,
-                            }
-                        ));
-                    }
-                }
+                tokens.append_all(quote!( self.#builder_field.or(#default_value).unwrap()));
             }
         };
 
         tokens.append_all(quote!(#struct_field:));
         append_rhs(tokens);
         tokens.append_all(quote!(,));
-    }
-}
-
-impl<'a> Initializer<'a> {
-    /// To be used inside of `#struct_field: match self.#builder_field { ... }`
-    fn match_some(&'a self) -> MatchSome {
-        match self.builder_pattern {
-            BuilderPattern::Owned => MatchSome::Move,
-            BuilderPattern::Mutable | BuilderPattern::Immutable => MatchSome::Clone {
-                crate_root: self.crate_root,
-            },
-        }
-    }
-
-    /// To be used inside of `#struct_field: match self.#builder_field { ... }`
-    fn match_none(&'a self) -> MatchNone<'a> {
-        match self.default_value {
-            Some(expr) => MatchNone::DefaultTo {
-                expr,
-                crate_root: self.crate_root,
-            },
-            None => {
-                if self.use_default_struct {
-                    MatchNone::UseDefaultStructField(self.field_ident)
-                } else {
-                    MatchNone::ReturnError {
-                        crate_root: self.crate_root,
-                        field_name: self.field_ident.to_string(),
-                        span: self.custom_error_type_span,
-                    }
-                }
-            }
-        }
-    }
-
-    fn default(&'a self) -> TokenStream {
-        let crate_root = self.crate_root;
-        match self.default_value {
-            Some(expr) => expr.with_crate_root(crate_root).into_token_stream(),
-            None if self.use_default_struct => {
-                let struct_ident = syn::Ident::new(DEFAULT_STRUCT_NAME, Span::call_site());
-                let field_ident = self.field_ident;
-                quote!(#struct_ident.#field_ident)
-            }
-            None => {
-                quote!(#crate_root::export::core::default::Default::default())
-            }
-        }
-    }
-}
-
-#[derive(Debug, Clone)]
-pub enum FieldConversion<'a> {
-    /// Usual conversion: unwrap the Option from the builder, or (hope to) use a default value
-    OptionOrDefault,
-    /// Custom conversion is a block contents expression
-    Block(&'a BlockContents),
-    /// Custom conversion is just to move the field from the builder
-    Move,
-}
-
-/// To be used inside of `#struct_field: match self.#builder_field { ... }`
-enum MatchNone<'a> {
-    /// Inner value must be a valid Rust expression
-    DefaultTo {
-        expr: &'a DefaultExpression,
-        crate_root: &'a syn::Path,
-    },
-    /// Inner value must be the field identifier
-    ///
-    /// The default struct must be in scope in the build_method.
-    UseDefaultStructField(&'a syn::Ident),
-    /// Inner value must be the field name
-    ReturnError {
-        crate_root: &'a syn::Path,
-        field_name: String,
-        span: Option<Span>,
-    },
-}
-
-impl<'a> ToTokens for MatchNone<'a> {
-    fn to_tokens(&self, tokens: &mut TokenStream) {
-        match *self {
-            MatchNone::DefaultTo { expr, crate_root } => {
-                let expr = expr.with_crate_root(crate_root);
-                tokens.append_all(quote!(None => #expr));
-            }
-            MatchNone::UseDefaultStructField(field_ident) => {
-                let struct_ident = syn::Ident::new(DEFAULT_STRUCT_NAME, Span::call_site());
-                tokens.append_all(quote!(
-                    None => #struct_ident.#field_ident
-                ))
-            }
-            MatchNone::ReturnError {
-                ref field_name,
-                ref span,
-                crate_root,
-            } => {
-                let conv_span = span.unwrap_or_else(Span::call_site);
-                // If the conversion fails, the compiler error should point to the error declaration
-                // rather than the crate root declaration, but the compiler will see the span of #crate_root
-                // and produce an undesired behavior (possibly because that's the first span in the bad expression?).
-                // Creating a copy with deeply-rewritten spans preserves the desired error behavior.
-                let crate_root = change_span(crate_root.into_token_stream(), conv_span);
-                let err_conv = quote_spanned!(conv_span => #crate_root::export::core::convert::Into::into(
-                    #crate_root::UninitializedFieldError::from(#field_name)
-                ));
-                tokens.append_all(quote!(
-                    None => return #crate_root::export::core::result::Result::Err(#err_conv)
-                ));
-            }
-        }
-    }
-}
-
-/// To be used inside of `#struct_field: match self.#builder_field { ... }`
-enum MatchSome<'a> {
-    Move,
-    Clone { crate_root: &'a syn::Path },
-}
-
-impl ToTokens for MatchSome<'_> {
-    fn to_tokens(&self, tokens: &mut TokenStream) {
-        match *self {
-            Self::Move => tokens.append_all(quote!(
-                Some(value) => value
-            )),
-            Self::Clone { crate_root } => tokens.append_all(quote!(
-                Some(ref value) => #crate_root::export::core::clone::Clone::clone(value)
-            )),
-        }
     }
 }
 

--- a/derive_builder_core/src/initializer.rs
+++ b/derive_builder_core/src/initializer.rs
@@ -55,19 +55,6 @@ pub struct Initializer<'a> {
     ///
     /// For sub-builder fields, this will be `build` (or similar)
     pub conversion: FieldConversion<'a>,
-
-    // TODO delete fields below here
-    //
-    /// Span where the macro was told to use a preexisting error type, instead of creating one,
-    /// to represent failures of the `build` method.
-    ///
-    /// An initializer can force early-return if a field has no set value and no default is
-    /// defined. In these cases, it will convert from `derive_builder::UninitializedFieldError`
-    /// into the return type of its enclosing `build` method. That conversion is guaranteed to
-    /// work for generated error types, but if the caller specified an error type to use instead
-    /// they may have forgotten the conversion from `UninitializedFieldError` into their specified
-    /// error type.
-    pub custom_error_type_span: Option<Span>,
 }
 
 impl<'a> ToTokens for Initializer<'a> {
@@ -150,7 +137,6 @@ macro_rules! default_initializer {
             default_value: None,
             use_default_struct: false,
             conversion: FieldConversion::OptionOrDefault,
-            custom_error_type_span: None,
         }
     };
 }

--- a/derive_builder_core/src/initializer.rs
+++ b/derive_builder_core/src/initializer.rs
@@ -1,7 +1,10 @@
 use proc_macro2::{Ident, Span, TokenStream};
 use quote::{ToTokens, TokenStreamExt};
 
-use crate::{BuilderPattern, DefaultExpression, FieldConversion, DEFAULT_FIELD_NAME_PREFIX};
+use crate::{
+    BuilderPattern, DefaultExpression, FieldConversion, DEFAULT_FIELD_NAME_PREFIX,
+    DEFAULT_STRUCT_NAME,
+};
 
 /// Initializer for the target struct fields, implementing `quote::ToTokens`.
 ///
@@ -38,19 +41,23 @@ pub struct Initializer<'a> {
     pub field_ident: &'a syn::Ident,
     /// Whether the builder implements a setter for this field.
     pub field_enabled: bool,
-
-    // TODO delete fields below here
-    //
-    /// Path to the root of the derive_builder crate.
-    pub crate_root: &'a syn::Path,
-    /// How the build method takes and returns `self` (e.g. mutably).
-    pub builder_pattern: BuilderPattern,
+    /// Method to use to to convert the builder's field to the target field
+    ///
+    /// For sub-builder fields, this will be `build` (or similar)
+    pub conversion: FieldConversion<'a>,
     /// Default value for the target field.
     ///
     /// This takes precedence over a default struct identifier.
     pub default_value: Option<&'a DefaultExpression>,
     /// Whether the build_method defines a default struct.
     pub use_default_struct: bool,
+    /// Path to the root of the derive_builder crate.
+    pub crate_root: &'a syn::Path,
+
+    // TODO delete fields below here
+    //
+    /// How the build method takes and returns `self` (e.g. mutably).
+    pub builder_pattern: BuilderPattern,
     /// Span where the macro was told to use a preexisting error type, instead of creating one,
     /// to represent failures of the `build` method.
     ///
@@ -61,10 +68,6 @@ pub struct Initializer<'a> {
     /// they may have forgotten the conversion from `UninitializedFieldError` into their specified
     /// error type.
     pub custom_error_type_span: Option<Span>,
-    /// Method to use to to convert the builder's field to the target field
-    ///
-    /// For sub-builder fields, this will be `build` (or similar)
-    pub conversion: FieldConversion<'a>,
 }
 
 impl<'a> ToTokens for Initializer<'a> {
@@ -72,23 +75,62 @@ impl<'a> ToTokens for Initializer<'a> {
         let struct_field = &self.field_ident;
         let builder_field = struct_field;
 
-        let default_value = Ident::new(
-            &format!("{}{}", DEFAULT_FIELD_NAME_PREFIX, struct_field),
-            Span::call_site(),
-        );
-
         // This structure prevents accidental failure to add the trailing `,` due to incautious `return`
         let append_rhs = |tokens: &mut TokenStream| {
             if !self.field_enabled {
-                tokens.append_all(quote!(#default_value));
+                tokens.append_all(self.default());
             } else {
-                tokens.append_all(quote!( self.#builder_field.or(#default_value).unwrap()));
+                match &self.conversion {
+                    FieldConversion::Move => tokens.append_all(quote!(self.#builder_field)),
+                    FieldConversion::OptionOrDefault => {
+                        let default_value = Ident::new(
+                            &format!("{}{}", DEFAULT_FIELD_NAME_PREFIX, struct_field),
+                            Span::call_site(),
+                        );
+
+                        let moved_or_cloned =
+                            self.move_or_clone_option(quote!(self.#builder_field));
+                        tokens.append_all(quote!( #moved_or_cloned.or(#default_value).unwrap()))
+                    }
+                    FieldConversion::Block(content) => content.to_tokens(tokens),
+                }
             }
         };
 
         tokens.append_all(quote!(#struct_field:));
         append_rhs(tokens);
         tokens.append_all(quote!(,));
+    }
+}
+
+impl<'a> Initializer<'a> {
+    fn move_or_clone_option(&'a self, value_in_option: TokenStream) -> TokenStream {
+        let crate_root = self.crate_root;
+
+        match self.builder_pattern {
+            BuilderPattern::Owned => value_in_option,
+            BuilderPattern::Mutable | BuilderPattern::Immutable => {
+                quote!(
+                    #value_in_option.as_ref()
+                        .map(|value| #crate_root::export::core::clone::Clone::clone(value))
+                )
+            }
+        }
+    }
+
+    fn default(&'a self) -> TokenStream {
+        let crate_root = self.crate_root;
+        match self.default_value {
+            Some(expr) => expr.with_crate_root(crate_root).into_token_stream(),
+            None if self.use_default_struct => {
+                let struct_ident = syn::Ident::new(DEFAULT_STRUCT_NAME, Span::call_site());
+                let field_ident = self.field_ident;
+                quote!(#struct_ident.#field_ident)
+            }
+            None => {
+                quote!(#crate_root::export::core::default::Default::default())
+            }
+        }
     }
 }
 

--- a/derive_builder_core/src/initializer.rs
+++ b/derive_builder_core/src/initializer.rs
@@ -37,33 +37,33 @@ use crate::{
 /// ```
 #[derive(Debug, Clone)]
 pub struct Initializer<'a> {
+    /// Path to the root of the derive_builder crate.
+    pub crate_root: &'a syn::Path,
     /// Name of the target field.
     pub field_ident: &'a syn::Ident,
     /// Whether the builder implements a setter for this field.
     pub field_enabled: bool,
-    /// Method to use to to convert the builder's field to the target field
-    ///
-    /// For sub-builder fields, this will be `build` (or similar)
-    pub conversion: FieldConversion<'a>,
+    /// How the build method takes and returns `self` (e.g. mutably).
+    pub builder_pattern: BuilderPattern,
     /// Default value for the target field.
     ///
     /// This takes precedence over a default struct identifier.
     pub default_value: Option<&'a DefaultExpression>,
     /// Whether the build_method defines a default struct.
     pub use_default_struct: bool,
-    /// Path to the root of the derive_builder crate.
-    pub crate_root: &'a syn::Path,
+    /// Method to use to to convert the builder's field to the target field
+    ///
+    /// For sub-builder fields, this will be `build` (or similar)
+    pub conversion: FieldConversion<'a>,
 
     // TODO delete fields below here
     //
-    /// How the build method takes and returns `self` (e.g. mutably).
-    pub builder_pattern: BuilderPattern,
     /// Span where the macro was told to use a preexisting error type, instead of creating one,
     /// to represent failures of the `build` method.
     ///
     /// An initializer can force early-return if a field has no set value and no default is
     /// defined. In these cases, it will convert from `derive_builder::UninitializedFieldError`
-    /// into thereturn type of its enclosing `build` method. That conversion is guaranteed to
+    /// into the return type of its enclosing `build` method. That conversion is guaranteed to
     /// work for generated error types, but if the caller specified an error type to use instead
     /// they may have forgotten the conversion from `UninitializedFieldError` into their specified
     /// error type.

--- a/derive_builder_core/src/lib.rs
+++ b/derive_builder_core/src/lib.rs
@@ -15,8 +15,7 @@
 //! [`derive_builder`]: https://!crates.io/crates/derive_builder
 //! [`derive_builder_core`]: https://!crates.io/crates/derive_builder_core
 
-// TODO reenable warnings for missing docs
-// #![deny(warnings, missing_docs)]
+#![deny(warnings, missing_docs)]
 #![cfg_attr(test, recursion_limit = "100")]
 
 #[macro_use]
@@ -55,8 +54,8 @@ use darling::FromDeriveInput;
 pub(crate) use default_expression::DefaultExpression;
 pub(crate) use deprecation_notes::DeprecationNotes;
 pub(crate) use doc_comment::doc_comment_from;
-pub(crate) use field_default_value::{FieldConversion, FieldDefaultValue};
-pub(crate) use initializer::Initializer;
+pub(crate) use field_default_value::FieldDefaultValue;
+pub(crate) use initializer::{FieldConversion, Initializer};
 pub(crate) use options::{BuilderPattern, Each};
 pub(crate) use setter::Setter;
 

--- a/derive_builder_core/src/lib.rs
+++ b/derive_builder_core/src/lib.rs
@@ -15,7 +15,8 @@
 //! [`derive_builder`]: https://!crates.io/crates/derive_builder
 //! [`derive_builder_core`]: https://!crates.io/crates/derive_builder_core
 
-#![deny(warnings, missing_docs)]
+// TODO reenable warnings for missing docs
+// #![deny(warnings, missing_docs)]
 #![cfg_attr(test, recursion_limit = "100")]
 
 #[macro_use]
@@ -39,6 +40,7 @@ mod change_span;
 mod default_expression;
 mod deprecation_notes;
 mod doc_comment;
+mod field_default_value;
 mod initializer;
 mod macro_options;
 mod options;
@@ -53,11 +55,13 @@ use darling::FromDeriveInput;
 pub(crate) use default_expression::DefaultExpression;
 pub(crate) use deprecation_notes::DeprecationNotes;
 pub(crate) use doc_comment::doc_comment_from;
-pub(crate) use initializer::{FieldConversion, Initializer};
+pub(crate) use field_default_value::{FieldConversion, FieldDefaultValue};
+pub(crate) use initializer::Initializer;
 pub(crate) use options::{BuilderPattern, Each};
 pub(crate) use setter::Setter;
 
 const DEFAULT_STRUCT_NAME: &str = "__default";
+const DEFAULT_FIELD_NAME_PREFIX: &str = "__default_";
 
 /// Derive a builder for a struct
 pub fn builder_for_struct(ast: syn::DeriveInput) -> proc_macro2::TokenStream {
@@ -83,6 +87,7 @@ pub fn builder_for_struct(ast: syn::DeriveInput) -> proc_macro2::TokenStream {
     for field in opts.fields() {
         builder.push_field(field.as_builder_field());
         builder.push_setter_fn(field.as_setter());
+        build_fn.push_default(field.as_default_value());
         build_fn.push_initializer(field.as_initializer());
     }
 

--- a/derive_builder_core/src/macro_options/darling_opts.rs
+++ b/derive_builder_core/src/macro_options/darling_opts.rs
@@ -897,12 +897,6 @@ impl<'a> FieldWithDefaults<'a> {
             default_value: self.field.default.as_ref(),
             use_default_struct: self.use_parent_default(),
             conversion: self.conversion(),
-            custom_error_type_span: self.parent.build_fn.error.as_ref().and_then(|err_ty| {
-                match err_ty {
-                    BuildFnError::Existing(p) => Some(p.span()),
-                    _ => None,
-                }
-            }),
         }
     }
 

--- a/derive_builder_core/src/macro_options/darling_opts.rs
+++ b/derive_builder_core/src/macro_options/darling_opts.rs
@@ -901,14 +901,18 @@ impl<'a> FieldWithDefaults<'a> {
     }
 
     pub fn as_default_value(&'a self) -> FieldDefaultValue<'a> {
+        let enabled = match self.conversion() {
+            FieldConversion::OptionOrDefault => true,
+            FieldConversion::Block(_) | FieldConversion::Move => false,
+        };
         FieldDefaultValue {
             crate_root: &self.parent.crate_root,
             field_ident: self.field_ident(),
             field_enabled: self.field_enabled(),
+            enabled,
             field_type: &self.field.ty,
             default_value: self.field.default.as_ref(),
             use_default_struct: self.use_parent_default(),
-            conversion: self.conversion(),
             custom_error_type_span: self.parent.build_fn.error.as_ref().and_then(|err_ty| {
                 match err_ty {
                     BuildFnError::Existing(p) => Some(p.span()),


### PR DESCRIPTION
This is a fix for #298

I finally got back to my hobby project where I need this so I got around to implement this feature/bug fix.

I've implemented the solution I described in that issue so I won't repeat it here again. If there are any open questions I'm happy to answer them or adjust this PR.

> You wouldn’t need that unwrap if you use unwrap_or, right?

No unwrap_or does not work because it expects a `T` and the default we have is an Option. Either we use or and than unwrap or we can use `unwrap_or(default.unwrap())`. I personally think that `or.unwrap` is a bit nicer. 

I know that the rust 1.59 tests are failing right now. "Syn" just published a new version "2.0.55" that requires rust 1.60.
However on my fork the 1.59 tests succeeded with the old syn version. 