### PR TITLE
forward default typeparam

### DIFF
--- a/derive_builder/src/lib.rs
+++ b/derive_builder/src/lib.rs
@@ -667,7 +667,7 @@
 //! - Tuple structs and unit structs are not supported as they have no field
 //!   names.
 //! - Generic setters introduce a type parameter `VALUE: Into<_>`. Therefore you can't use
-//!  `VALUE` as a type parameter on a generic struct in combination with generic setters.
+//!   `VALUE` as a type parameter on a generic struct in combination with generic setters.
 //! - The `try_setter` attribute and `owned` builder pattern are not compatible in practice;
 //!   an error during building will consume the builder, making it impossible to continue
 //!   construction.

--- a/derive_builder/tests/run-pass/default_typeparams.rs
+++ b/derive_builder/tests/run-pass/default_typeparams.rs
@@ -1,0 +1,30 @@
+//! Test ensuring that default type params gets forwarded to Builder.
+
+#[macro_use]
+extern crate derive_builder;
+
+#[derive(Builder)]
+#[builder(setter(strip_option))]
+struct Settings<T, U = (), C = fn(T) -> U> {
+    first: T,
+    #[builder(default)]
+    second: Option<U>,
+    #[builder(default)]
+    third: Option<C>,
+}
+
+fn main() {
+    SettingsBuilder::<usize>::default()
+        .first(1)
+        .second(())
+        .third(|_: usize| ())
+        .build()
+        .unwrap();
+
+    SettingsBuilder::<usize, usize>::default()
+        .first(1)
+        .second(2)
+        .third(|_: usize| 3)
+        .build()
+        .unwrap();
+}

--- a/derive_builder_core/src/macro_options/darling_opts.rs
+++ b/derive_builder_core/src/macro_options/darling_opts.rs
@@ -151,7 +151,7 @@ pub struct BuildFn {
     /// * `validation_error = bool` - Whether to generate `ValidationError(String)` as a variant
     ///   of the build error type. Setting this to `false` will prevent `derive_builder` from
     ///   using the `validate` function but this also means it does not generate any usage of the
-    ///  `alloc` crate (useful when disabling the `alloc` feature in `no_std`).
+    ///   `alloc` crate (useful when disabling the `alloc` feature in `no_std`).
     ///
     /// # Type Bounds for Custom Error
     /// This type's bounds depend on other settings of the builder.

--- a/derive_builder_no_alloc_tests/src/lib.rs
+++ b/derive_builder_no_alloc_tests/src/lib.rs
@@ -1,5 +1,5 @@
 #![no_std]
-#![allow(unused, clippy::blacklisted_name)]
+#![allow(unused, clippy::disallowed_names)]
 
 use derive_builder::{self, Builder};
 


### PR DESCRIPTION
the derived builder doesn't offer the same default types as the source struct. that forces the user to explicit all types when theses can't be infered.

in the case I have, I want to derive a builder on a struct with a bunch of callbacks:
```rust
pub struct Settings<T, S = fn(T), R = fn(T), C = fn(T)>
where S: FnOnce(T), R: FnMut(T), C: FnMut(T)
```
on which I only need to specific `T` when instanciating `Settings` "by hand". but when using the derived builder, I need to specifiy *all* the types (which is especially cumbersome as most of theses callbacks are optional).

there was a confusion in the implementation between generics meant for the builder struct (which [can contain default types](https://doc.rust-lang.org/book/ch19-03-advanced-traits.html#default-generic-type-parameters-and-operator-overloading)) and the ones for `impl` (which [can't contain theses](https://github.com/rust-lang/rust/issues/36887)). this PR fixes that by directly using the generics specified on the struct (with bounds and defaults), and a test to guard against regression for this kinda obscure feature.

I encountered dtolnay/syn#782 while doing that but as it seems that upstream seems to have forgot this issue, a workaround seemed better.