### PR TITLE
Impl core::error::Error instead of std::error::Error

### DIFF
--- a/derive_builder_core/src/builder.rs
+++ b/derive_builder_core/src/builder.rs
@@ -145,6 +145,7 @@ pub struct Builder<'a> {
     /// Doc-comment of the builder struct.
     pub doc_comment: Option<syn::Attribute>,
     /// Whether or not a libstd is used.
+    #[allow(dead_code)]
     pub std: bool,
 }
 
@@ -294,11 +295,9 @@ impl<'a> ToTokens for Builder<'a> {
                     }
                 ));
 
-                if self.std {
-                    tokens.append_all(quote!(
-                        impl std::error::Error for #builder_error_ident {}
-                    ));
-                }
+                tokens.append_all(quote!(
+                    impl core::error::Error for #builder_error_ident {}
+                ));
             }
         }
     }


### PR DESCRIPTION
Hey there,

thanks for the great library! I noticed that the Error trait is not implemented for BuilderErrors when the `std` feature is inactive. Rust 1.81 stabilized core::error::Error, it would be nice if this crate could make use of it and lift the former restriction. Since, as implemented, this would be a breaking change, I'm wondering what the preferred way forward is. I can think of

- add a feature flag, like `core_error` that opts into using core::error::Error instead of the std version
- use something like https://crates.io/crates/rustversion/ to gate the core version behind a  `#[rustversion::since(1.81)]`
- others?